### PR TITLE
chore: Add back in earn learn more bottom sheet

### DIFF
--- a/packages/@interaxyz/mobile/src/earn/EarnHome.test.tsx
+++ b/packages/@interaxyz/mobile/src/earn/EarnHome.test.tsx
@@ -3,9 +3,11 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
+import { getAppConfig } from 'src/appConfig'
 import EarnHome from 'src/earn/EarnHome'
 import { Status } from 'src/earn/slice'
 import { EarnTabType } from 'src/earn/types'
+import { PublicAppConfig } from 'src/public/types'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
@@ -14,6 +16,19 @@ import { createMockStore } from 'test/utils'
 import { mockEarnPositions, mockTokenBalances } from 'test/values'
 
 jest.mock('src/statsig')
+jest.mock('src/appConfig')
+
+const mockGetAppConfig = jest.mocked(getAppConfig)
+const defaultConfig: PublicAppConfig = {
+  registryName: 'test',
+  displayName: 'test',
+  deepLinkUrlScheme: 'test',
+  experimental: {
+    earn: {
+      showLearnMore: true,
+    }
+  }
+}
 
 function getStore(
   mockPoolBalance: string = '0',
@@ -54,6 +69,7 @@ describe('EarnHome', () => {
       .mockImplementation(
         (featureGateName) => featureGateName === StatsigFeatureGates.SHOW_POSITIONS
       )
+      mockGetAppConfig.mockReturnValue(defaultConfig)
   })
   it('shows the zero state UI under my pools if the user has no pools with balance', () => {
     const { getByText } = render(

--- a/packages/@interaxyz/mobile/src/earn/EarnHome.test.tsx
+++ b/packages/@interaxyz/mobile/src/earn/EarnHome.test.tsx
@@ -26,8 +26,8 @@ const defaultConfig: PublicAppConfig = {
   experimental: {
     earn: {
       showLearnMore: true,
-    }
-  }
+    },
+  },
 }
 
 function getStore(
@@ -69,7 +69,7 @@ describe('EarnHome', () => {
       .mockImplementation(
         (featureGateName) => featureGateName === StatsigFeatureGates.SHOW_POSITIONS
       )
-      mockGetAppConfig.mockReturnValue(defaultConfig)
+    mockGetAppConfig.mockReturnValue(defaultConfig)
   })
   it('shows the zero state UI under my pools if the user has no pools with balance', () => {
     const { getByText } = render(

--- a/packages/@interaxyz/mobile/src/earn/PoolList.tsx
+++ b/packages/@interaxyz/mobile/src/earn/PoolList.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from 'react-native'
 import Animated from 'react-native-reanimated'
+import { getAppConfig } from 'src/appConfig'
 import PoolCard from 'src/earn/PoolCard'
 import { EarnPosition } from 'src/positions/types'
 import { typeScale } from 'src/styles/fonts'
@@ -30,6 +31,8 @@ export default function PoolList({
   displayPools: EarnPosition[]
   onPressLearnMore: () => void
 }) {
+  const appConfig = getAppConfig()
+  const showLearnMore = appConfig.experimental?.earn?.showLearnMore ?? false
   return (
     <AnimatedFlatList
       data={displayPools}
@@ -40,7 +43,7 @@ export default function PoolList({
       scrollIndicatorInsets={{ top: 0.01 }}
       scrollEventThrottle={16}
       ListHeaderComponent={<View style={{ height: listHeaderHeight }} />}
-      ListFooterComponent={
+      ListFooterComponent={ showLearnMore ? (
         <Text style={styles.learnMore}>
           <Trans i18nKey="earnFlow.home.learnMore">
             <Text
@@ -49,7 +52,7 @@ export default function PoolList({
               testID="LearnMoreCta"
             ></Text>
           </Trans>
-        </Text>
+        </Text> ) : null
       }
       style={styles.sectionList}
       contentContainerStyle={[

--- a/packages/@interaxyz/mobile/src/earn/PoolList.tsx
+++ b/packages/@interaxyz/mobile/src/earn/PoolList.tsx
@@ -43,16 +43,18 @@ export default function PoolList({
       scrollIndicatorInsets={{ top: 0.01 }}
       scrollEventThrottle={16}
       ListHeaderComponent={<View style={{ height: listHeaderHeight }} />}
-      ListFooterComponent={ showLearnMore ? (
-        <Text style={styles.learnMore}>
-          <Trans i18nKey="earnFlow.home.learnMore">
-            <Text
-              style={styles.learnMoreLink}
-              onPress={onPressLearnMore}
-              testID="LearnMoreCta"
-            ></Text>
-          </Trans>
-        </Text> ) : null
+      ListFooterComponent={
+        showLearnMore ? (
+          <Text style={styles.learnMore}>
+            <Trans i18nKey="earnFlow.home.learnMore">
+              <Text
+                style={styles.learnMoreLink}
+                onPress={onPressLearnMore}
+                testID="LearnMoreCta"
+              ></Text>
+            </Trans>
+          </Text>
+        ) : null
       }
       style={styles.sectionList}
       contentContainerStyle={[

--- a/packages/@interaxyz/mobile/src/earn/TabEarn.tsx
+++ b/packages/@interaxyz/mobile/src/earn/TabEarn.tsx
@@ -16,7 +16,7 @@ import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
 import { AppState } from 'src/app/actions'
 import { appStateSelector, phoneNumberVerifiedSelector } from 'src/app/selectors'
-import { BottomSheetModalRefType } from 'src/components/BottomSheet'
+import BottomSheet, { BottomSheetModalRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import {
   ALERT_BANNER_DURATION,
@@ -255,7 +255,38 @@ function TabHome({ navigation, route }: Props) {
           />
         )}
       </Animated.View>
+      <LearnMoreBottomSheet learnMoreBottomSheetRef={learnMoreBottomSheetRef} />
     </>
+  )
+}
+
+function LearnMoreBottomSheet({
+  learnMoreBottomSheetRef,
+}: {
+  learnMoreBottomSheetRef: React.RefObject<BottomSheetModalRefType>
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <BottomSheet
+      forwardedRef={learnMoreBottomSheetRef}
+      title={t('earnFlow.home.learnMoreBottomSheet.bottomSheetTitle')}
+      testId={'Earn/Home/LearnMoreBottomSheet'}
+      titleStyle={styles.learnMoreTitle}
+    >
+      <Text style={styles.learnMoreSubTitle}>
+        {t('earnFlow.home.learnMoreBottomSheet.yieldPoolSubtitle')}
+      </Text>
+      <Text style={styles.learnMoreDescription}>
+        {t('earnFlow.home.learnMoreBottomSheet.yieldPoolDescription')}
+      </Text>
+      <Text style={styles.learnMoreSubTitle}>
+        {t('earnFlow.home.learnMoreBottomSheet.chooseSubtitle')}
+      </Text>
+      <Text style={styles.learnMoreDescription}>
+        {t('earnFlow.home.learnMoreBottomSheet.chooseDescription')}
+      </Text>
+    </BottomSheet>
   )
 }
 
@@ -303,6 +334,17 @@ const styles = StyleSheet.create({
     ...typeScale.bodySmall,
     textAlign: 'center',
     marginVertical: Spacing.Regular16,
+  },
+  learnMoreTitle: {
+    ...typeScale.titleSmall,
+  },
+  learnMoreSubTitle: {
+    ...typeScale.labelSemiBoldSmall,
+    marginBottom: Spacing.Tiny4,
+  },
+  learnMoreDescription: {
+    ...typeScale.bodySmall,
+    marginBottom: Spacing.Thick24,
   },
 })
 

--- a/packages/@interaxyz/mobile/src/public/types.tsx
+++ b/packages/@interaxyz/mobile/src/public/types.tsx
@@ -1,4 +1,4 @@
-import type { ImageSourcePropType } from 'react-native';
+import type { ImageSourcePropType } from 'react-native'
 
 // Type for tab configuration
 export interface TabScreenConfig {

--- a/packages/@interaxyz/mobile/src/public/types.tsx
+++ b/packages/@interaxyz/mobile/src/public/types.tsx
@@ -1,4 +1,4 @@
-import type { ImageSourcePropType } from 'react-native'
+import type { ImageSourcePropType } from 'react-native';
 
 // Type for tab configuration
 export interface TabScreenConfig {
@@ -178,6 +178,9 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
     onboarding?: {
       enableBiometry?: boolean
       protectWallet?: boolean
+    }
+    earn: {
+      showLearnMore?: boolean
     }
   }
 }


### PR DESCRIPTION
### Description

This was missed when copying over the home screen from beefy (where it was removed), but it should exist here since it is sometimes used (like in Valora).

Configurable with `experimental.earn.showLearnMore`

### Test plan

<img src="https://github.com/user-attachments/assets/1f421f10-eb98-4c2f-9ecd-88427552fd52" width="250" />

### Related issues

- N/A

### Backwards compatibility

N/A
### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
