### PR TITLE
fix(format): Prevent prettier from formatting RootStateSchema

### DIFF
--- a/packages/@divvi/mobile/.prettierignore
+++ b/packages/@divvi/mobile/.prettierignore
@@ -1,0 +1,15 @@
+package.json
+**/.next
+**/coverage
+**/node_modules
+**/privacy/*
+.git/
+
+# Ignore Crowdin generated files (often they are written with no final newline)
+locales/*/*.json
+# Except for the base lang which is maintained by hand
+!locales/base/*.json
+src/pincode/pin-blocklist-hibpv7-top-25k-with-keyboard-translations.json
+
+# Ignore generated RootState schema
+test/RootStateSchema.json


### PR DESCRIPTION
### Description

When running `yarn format` from within the `packages/@divvi/mobile/` directory, prettier does not see/use the `.prettierignore` in the repo top-level directory. Adding this in prevents `yarn format` from mangling `RootStateSchema.json` in particular.