### PR TITLE
feat: public api for preparing/sending transactions

### DIFF
--- a/packages/@divvi/mobile/src/analytics/types.ts
+++ b/packages/@divvi/mobile/src/analytics/types.ts
@@ -43,3 +43,4 @@ export type TransactionOrigin =
   | 'jumpstart-claim'
   | 'wallet-connect'
   | 'shortcut'
+  | 'framework'

--- a/packages/@divvi/mobile/src/public/getFees.test.ts
+++ b/packages/@divvi/mobile/src/public/getFees.test.ts
@@ -1,0 +1,24 @@
+import { getFeeCurrencyAndAmounts } from '../viem/prepareTransactions'
+import { getFees } from './getFees'
+import type { PreparedTransactionsPossible } from './prepareTransactions'
+
+jest.mock('../viem/prepareTransactions')
+
+describe('getFees', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(getFeeCurrencyAndAmounts).mockReset()
+  })
+
+  it('should delegate to getFeeCurrencyAndAmounts', () => {
+    const mockPreparedResult = { type: 'possible' } as PreparedTransactionsPossible
+    const mockFees = {} as any
+
+    jest.mocked(getFeeCurrencyAndAmounts).mockReturnValue(mockFees)
+
+    const result = getFees(mockPreparedResult)
+
+    expect(result).toEqual(mockFees)
+    expect(getFeeCurrencyAndAmounts).toHaveBeenCalledWith(mockPreparedResult)
+  })
+})

--- a/packages/@divvi/mobile/src/public/getFees.ts
+++ b/packages/@divvi/mobile/src/public/getFees.ts
@@ -1,5 +1,5 @@
 import type { GetFeeCurrencyAndAmounts } from '../viem/prepareTransactions'
-import type { PreparedTransactionsResult } from './prepareTransactionsTypes'
+import type { PreparedTransactionsResult } from './prepareTransactions'
 
 export function getFees(prepareTransactionsResult: PreparedTransactionsResult | undefined) {
   const getFeeCurrencyAndAmounts = require('../viem/prepareTransactions')

--- a/packages/@divvi/mobile/src/public/getFees.ts
+++ b/packages/@divvi/mobile/src/public/getFees.ts
@@ -1,0 +1,8 @@
+import type { GetFeeCurrencyAndAmounts } from '../viem/prepareTransactions'
+import type { PreparedTransactionsResult } from './prepareTransactionsTypes'
+
+export function getFees(prepareTransactionsResult: PreparedTransactionsResult | undefined) {
+  const getFeeCurrencyAndAmounts = require('../viem/prepareTransactions')
+    .getFeeCurrencyAndAmounts as GetFeeCurrencyAndAmounts
+  return getFeeCurrencyAndAmounts(prepareTransactionsResult)
+} 

--- a/packages/@divvi/mobile/src/public/getFees.ts
+++ b/packages/@divvi/mobile/src/public/getFees.ts
@@ -5,4 +5,4 @@ export function getFees(prepareTransactionsResult: PreparedTransactionsResult | 
   const getFeeCurrencyAndAmounts = require('../viem/prepareTransactions')
     .getFeeCurrencyAndAmounts as GetFeeCurrencyAndAmounts
   return getFeeCurrencyAndAmounts(prepareTransactionsResult)
-} 
+}

--- a/packages/@divvi/mobile/src/public/hooks/toAsyncStatus.ts
+++ b/packages/@divvi/mobile/src/public/hooks/toAsyncStatus.ts
@@ -1,0 +1,19 @@
+import { AsyncStateStatus } from 'react-async-hook'
+
+type AsyncStatus = 'idle' | 'loading' | 'success' | 'error'
+
+export function toAsyncStatus(status: AsyncStateStatus): AsyncStatus {
+  switch (status) {
+    case 'not-requested':
+      return 'idle'
+    case 'loading':
+      return 'loading'
+    case 'success':
+      return 'success'
+    case 'error':
+      return 'error'
+    default:
+      const exhaustiveCheck: never = status
+      return exhaustiveCheck
+  }
+}

--- a/packages/@divvi/mobile/src/public/hooks/usePrepareTransactions.test.ts
+++ b/packages/@divvi/mobile/src/public/hooks/usePrepareTransactions.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook } from '@testing-library/react-native'
+import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
+import { mockAccount } from 'test/values'
+import { prepareTransactions } from '../prepareTransactions'
+import { usePrepareTransactions } from './usePrepareTransactions'
+
+jest.mock('../prepareTransactions')
+const mockPrepareTransactions = jest.mocked(prepareTransactions)
+
+// This test focuses on the key integration points of the hook, avoiding testing react-async-hook which is already tested
+describe('usePrepareTransactions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockPrepareTransactions.mockReset()
+  })
+
+  it('should provide preparation functionality and expose results', async () => {
+    const mockResult = { type: 'possible' } as PreparedTransactionsPossible
+    mockPrepareTransactions.mockResolvedValueOnce(mockResult)
+
+    const { result } = renderHook(() => usePrepareTransactions())
+
+    await act(async () => {
+      await result.current.prepareTransactions({
+        networkId: 'celo-mainnet',
+        transactionRequests: [
+          {
+            to: mockAccount,
+            value: BigInt(1),
+          },
+        ],
+      })
+    })
+
+    expect(mockPrepareTransactions).toHaveBeenCalledTimes(1)
+    expect(result.current.data).toEqual(mockResult)
+    expect(result.current.status).toEqual('success')
+  })
+
+  it('should expose errors when preparation fails', async () => {
+    const mockError = new Error('Preparation failed')
+    mockPrepareTransactions.mockRejectedValueOnce(mockError)
+
+    const { result } = renderHook(() => usePrepareTransactions())
+
+    await act(async () => {
+      await expect(
+        result.current.prepareTransactions({
+          networkId: 'celo-mainnet',
+          transactionRequests: [
+            {
+              to: mockAccount,
+              value: BigInt(1),
+            },
+          ],
+        })
+      ).rejects.toThrow(mockError)
+    })
+
+    expect(result.current.error).toBe(mockError)
+    expect(result.current.status).toEqual('error')
+  })
+})

--- a/packages/@divvi/mobile/src/public/hooks/usePrepareTransactions.test.ts
+++ b/packages/@divvi/mobile/src/public/hooks/usePrepareTransactions.test.ts
@@ -1,7 +1,6 @@
 import { act, renderHook } from '@testing-library/react-native'
-import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
 import { mockAccount } from 'test/values'
-import { prepareTransactions } from '../prepareTransactions'
+import { PreparedTransactionsPossible, prepareTransactions } from '../prepareTransactions'
 import { usePrepareTransactions } from './usePrepareTransactions'
 
 jest.mock('../prepareTransactions')

--- a/packages/@divvi/mobile/src/public/hooks/usePrepareTransactions.ts
+++ b/packages/@divvi/mobile/src/public/hooks/usePrepareTransactions.ts
@@ -1,0 +1,15 @@
+import { useAsyncCallback } from 'react-async-hook'
+import { prepareTransactions } from '../prepareTransactions'
+import { toAsyncStatus } from './toAsyncStatus'
+
+export function usePrepareTransactions() {
+  const asyncCallback = useAsyncCallback(prepareTransactions)
+
+  return {
+    status: toAsyncStatus(asyncCallback.status),
+    error: asyncCallback.error,
+    data: asyncCallback.result,
+    prepareTransactions: asyncCallback.execute,
+    reset: asyncCallback.reset,
+  }
+}

--- a/packages/@divvi/mobile/src/public/hooks/useSendTransactions.test.ts
+++ b/packages/@divvi/mobile/src/public/hooks/useSendTransactions.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook } from '@testing-library/react-native'
+import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
+import { sendPreparedTransactions } from '../prepareTransactions'
+import { useSendTransactions } from './useSendTransactions'
+
+jest.mock('../prepareTransactions')
+const mockSendPreparedTransactions = jest.mocked(sendPreparedTransactions)
+
+const mockPreparedTransactions = { type: 'possible' } as PreparedTransactionsPossible
+
+// This test focuses on the key integration points of the hook, avoiding testing react-async-hook which is already tested
+describe('usePrepareTransactions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockSendPreparedTransactions.mockReset()
+  })
+
+  it('should provide sending functionality and expose results', async () => {
+    const mockResult = ['0x123' as `0x${string}`]
+    mockSendPreparedTransactions.mockResolvedValueOnce(mockResult)
+
+    const { result } = renderHook(() => useSendTransactions())
+
+    await act(async () => {
+      await result.current.sendTransactions(mockPreparedTransactions)
+    })
+
+    expect(mockSendPreparedTransactions).toHaveBeenCalledTimes(1)
+    expect(result.current.data).toEqual(mockResult)
+    expect(result.current.status).toEqual('success')
+  })
+
+  it('should expose errors when sending fails', async () => {
+    const mockError = new Error('Sending failed')
+    mockSendPreparedTransactions.mockRejectedValueOnce(mockError)
+
+    const { result } = renderHook(() => useSendTransactions())
+
+    await act(async () => {
+      await expect(result.current.sendTransactions(mockPreparedTransactions)).rejects.toThrow(
+        mockError
+      )
+    })
+
+    expect(result.current.error).toBe(mockError)
+    expect(result.current.status).toEqual('error')
+  })
+})

--- a/packages/@divvi/mobile/src/public/hooks/useSendTransactions.test.ts
+++ b/packages/@divvi/mobile/src/public/hooks/useSendTransactions.test.ts
@@ -1,10 +1,10 @@
 import { act, renderHook } from '@testing-library/react-native'
-import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
-import { sendPreparedTransactions } from '../prepareTransactions'
+import type { PreparedTransactionsPossible } from '../prepareTransactions'
+import { sendTransactions } from '../sendTransactions'
 import { useSendTransactions } from './useSendTransactions'
 
-jest.mock('../prepareTransactions')
-const mockSendPreparedTransactions = jest.mocked(sendPreparedTransactions)
+jest.mock('../sendTransactions')
+const mockSendPreparedTransactions = jest.mocked(sendTransactions)
 
 const mockPreparedTransactions = { type: 'possible' } as PreparedTransactionsPossible
 

--- a/packages/@divvi/mobile/src/public/hooks/useSendTransactions.ts
+++ b/packages/@divvi/mobile/src/public/hooks/useSendTransactions.ts
@@ -1,0 +1,15 @@
+import { useAsyncCallback } from 'react-async-hook'
+import { sendPreparedTransactions } from '../prepareTransactions'
+import { toAsyncStatus } from './toAsyncStatus'
+
+export function useSendTransactions() {
+  const asyncCallback = useAsyncCallback(sendPreparedTransactions)
+
+  return {
+    status: toAsyncStatus(asyncCallback.status),
+    error: asyncCallback.error,
+    data: asyncCallback.result,
+    sendTransactions: asyncCallback.execute,
+    reset: asyncCallback.reset,
+  }
+}

--- a/packages/@divvi/mobile/src/public/hooks/useSendTransactions.ts
+++ b/packages/@divvi/mobile/src/public/hooks/useSendTransactions.ts
@@ -1,9 +1,9 @@
 import { useAsyncCallback } from 'react-async-hook'
-import { sendPreparedTransactions } from '../prepareTransactions'
+import { sendTransactions } from '../sendTransactions'
 import { toAsyncStatus } from './toAsyncStatus'
 
 export function useSendTransactions() {
-  const asyncCallback = useAsyncCallback(sendPreparedTransactions)
+  const asyncCallback = useAsyncCallback(sendTransactions)
 
   return {
     status: toAsyncStatus(asyncCallback.status),

--- a/packages/@divvi/mobile/src/public/index.ts
+++ b/packages/@divvi/mobile/src/public/index.ts
@@ -6,16 +6,17 @@
  * - Prevent accidental exposure of internal implementation details
  */
 export { createApp } from './createApp'
+export { getFees } from './getFees'
 export { usePrepareTransactions } from './hooks/usePrepareTransactions'
 export { useSendTransactions } from './hooks/useSendTransactions'
 export { useWallet } from './hooks/useWallet'
 export {
-  getFees,
   prepareTransactions,
-  sendPreparedTransactions,
   type PreparedTransactionsNeedDecreaseSpendAmountForGas,
   type PreparedTransactionsNotEnoughBalanceForGas,
   type PreparedTransactionsPossible,
   type PreparedTransactionsResult,
+  type TransactionRequest,
 } from './prepareTransactions'
+export { sendTransactions as sendPreparedTransactions } from './sendTransactions'
 export { type NetworkId, type PublicAppConfig } from './types'

--- a/packages/@divvi/mobile/src/public/index.ts
+++ b/packages/@divvi/mobile/src/public/index.ts
@@ -6,5 +6,16 @@
  * - Prevent accidental exposure of internal implementation details
  */
 export { createApp } from './createApp'
+export { usePrepareTransactions } from './hooks/usePrepareTransactions'
+export { useSendTransactions } from './hooks/useSendTransactions'
 export { useWallet } from './hooks/useWallet'
-export { type PublicAppConfig } from './types'
+export {
+  getFees,
+  prepareTransactions,
+  sendPreparedTransactions,
+  type PreparedTransactionsNeedDecreaseSpendAmountForGas,
+  type PreparedTransactionsNotEnoughBalanceForGas,
+  type PreparedTransactionsPossible,
+  type PreparedTransactionsResult,
+} from './prepareTransactions'
+export { type NetworkId, type PublicAppConfig } from './types'

--- a/packages/@divvi/mobile/src/public/index.ts
+++ b/packages/@divvi/mobile/src/public/index.ts
@@ -18,5 +18,5 @@ export {
   type PreparedTransactionsResult,
   type TransactionRequest,
 } from './prepareTransactions'
-export { sendTransactions as sendPreparedTransactions } from './sendTransactions'
+export { sendTransactions } from './sendTransactions'
 export { type NetworkId, type PublicAppConfig } from './types'

--- a/packages/@divvi/mobile/src/public/prepareTransactions.test.ts
+++ b/packages/@divvi/mobile/src/public/prepareTransactions.test.ts
@@ -1,0 +1,107 @@
+import { getSerializablePreparedTransactions } from 'src/viem/preparedTransactionSerialization'
+import { mockAccount, mockCeloTokenBalance } from 'test/values'
+import { feeCurrenciesSelector } from '../tokens/selectors'
+import {
+  getFeeCurrencyAndAmounts,
+  prepareTransactions as internalPrepareTransactions,
+  PreparedTransactionsPossible,
+} from '../viem/prepareTransactions'
+import { sendPreparedTransactions as sendPreparedTransactionsSaga } from '../viem/saga'
+import {
+  getFees,
+  prepareTransactions,
+  sendPreparedTransactions,
+  type TransactionRequest,
+} from './prepareTransactions'
+
+jest.mock('../tokens/selectors')
+jest.mock('../viem/prepareTransactions')
+jest.mock('../viem/saga')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+
+  // Reset all mock implementations and return values
+  jest.mocked(feeCurrenciesSelector).mockReset()
+  jest.mocked(internalPrepareTransactions).mockReset()
+  jest.mocked(getFeeCurrencyAndAmounts).mockReset()
+  jest.mocked(sendPreparedTransactionsSaga).mockReset()
+})
+
+describe('prepareTransactions', () => {
+  it('should correctly prepare transactions', async () => {
+    const mockFeeCurrencies = [mockCeloTokenBalance]
+    const mockPrepareResult = { type: 'possible' } as PreparedTransactionsPossible
+
+    jest.mocked(feeCurrenciesSelector).mockReturnValue(mockFeeCurrencies)
+    jest.mocked(internalPrepareTransactions).mockResolvedValue(mockPrepareResult)
+
+    const txRequests: TransactionRequest[] = [
+      {
+        to: '0x1234567890123456789012345678901234567890',
+        data: '0x',
+        value: BigInt(1000),
+        estimatedGasUse: BigInt(21000),
+      },
+    ]
+
+    const result = await prepareTransactions({
+      networkId: 'celo-alfajores',
+      transactionRequests: txRequests,
+    })
+
+    expect(result).toEqual(mockPrepareResult)
+    expect(internalPrepareTransactions).toHaveBeenCalledWith({
+      feeCurrencies: mockFeeCurrencies,
+      decreasedAmountGasFeeMultiplier: 1,
+      baseTransactions: [
+        {
+          to: txRequests[0].to,
+          data: txRequests[0].data,
+          value: txRequests[0].value,
+          _estimatedGasUse: txRequests[0].estimatedGasUse,
+        },
+      ],
+      origin: 'framework',
+    })
+  })
+})
+
+describe('getFees', () => {
+  it('should delegate to getFeeCurrencyAndAmounts', () => {
+    const mockPreparedResult = { type: 'possible' } as PreparedTransactionsPossible
+    const mockFees = {} as any
+
+    jest.mocked(getFeeCurrencyAndAmounts).mockReturnValue(mockFees)
+
+    const result = getFees(mockPreparedResult as any)
+
+    expect(result).toEqual(mockFees)
+    expect(getFeeCurrencyAndAmounts).toHaveBeenCalledWith(mockPreparedResult)
+  })
+})
+
+describe('sendPreparedTransactions', () => {
+  it('should correctly send prepared transactions', async () => {
+    const mockTxHashes = ['0x123', '0x456']
+    const mockPrepared = {
+      type: 'possible',
+      transactions: [
+        { to: mockAccount, value: BigInt(1000) },
+        { to: mockAccount, value: BigInt(1000) },
+      ],
+      feeCurrency: mockCeloTokenBalance,
+    } as PreparedTransactionsPossible
+
+    jest.mocked(sendPreparedTransactionsSaga).mockReturnValue(mockTxHashes as any)
+
+    const result = await sendPreparedTransactions(mockPrepared as any)
+
+    expect(result).toEqual(mockTxHashes)
+    expect(sendPreparedTransactionsSaga).toHaveBeenCalledWith(
+      getSerializablePreparedTransactions(mockPrepared.transactions),
+      'celo-alfajores',
+      expect.any(Array)
+    )
+  })
+})

--- a/packages/@divvi/mobile/src/public/prepareTransactions.ts
+++ b/packages/@divvi/mobile/src/public/prepareTransactions.ts
@@ -1,0 +1,98 @@
+// See useWallet for why we don't directly import internal modules, except for the types
+import { call } from 'typed-redux-saga'
+import type { Address, Hex } from 'viem'
+import type { RunSaga, Store } from '../redux/store'
+import type { FeeCurrenciesSelector } from '../tokens/selectors'
+import type { NetworkId as InternalNetworkId } from '../transactions/types'
+import type {
+  GetFeeCurrencyAndAmounts,
+  TransactionRequest as InternalTransactionRequest,
+  PreparedTransactionsPossible,
+  PreparedTransactionsResult,
+  PrepareTransactions,
+} from '../viem/prepareTransactions'
+import type { GetSerializablePreparedTransactions } from '../viem/preparedTransactionSerialization'
+import type { SendPreparedTransactions } from '../viem/saga'
+import type { NetworkId } from './types'
+
+export type {
+  PreparedTransactionsNeedDecreaseSpendAmountForGas,
+  PreparedTransactionsNotEnoughBalanceForGas,
+  PreparedTransactionsPossible,
+  PreparedTransactionsResult,
+} from '../viem/prepareTransactions'
+
+export type TransactionRequest = {
+  to: Address
+  data?: Hex
+  value?: bigint
+  // These are needed when preparing more than one transaction
+  gas?: bigint // in wei
+  estimatedGasUse?: bigint // in wei
+}
+
+function toInternalTransactionRequest(tx: TransactionRequest): InternalTransactionRequest {
+  return {
+    to: tx.to,
+    value: tx.value,
+    data: tx.data,
+    gas: tx.gas,
+    _estimatedGasUse: tx.estimatedGasUse,
+  }
+}
+
+function toInternalTransactionRequests(txs: TransactionRequest[]): InternalTransactionRequest[] {
+  return txs.map(toInternalTransactionRequest)
+}
+
+export async function prepareTransactions({
+  networkId,
+  transactionRequests,
+}: {
+  networkId: NetworkId
+  transactionRequests: TransactionRequest[]
+}) {
+  const store = require('../redux/store').store as Store
+  const feeCurrenciesSelector = require('../tokens/selectors')
+    .feeCurrenciesSelector as FeeCurrenciesSelector
+  const prepareTransactions = require('../viem/prepareTransactions')
+    .prepareTransactions as PrepareTransactions
+
+  const feeCurrencies = feeCurrenciesSelector(store.getState(), networkId as InternalNetworkId)
+  const result = await prepareTransactions({
+    feeCurrencies,
+    decreasedAmountGasFeeMultiplier: 1,
+    baseTransactions: toInternalTransactionRequests(transactionRequests),
+    origin: 'framework',
+  })
+  return result
+}
+
+export function getFees(prepareTransactionsResult: PreparedTransactionsResult | undefined) {
+  const getFeeCurrencyAndAmounts = require('../viem/prepareTransactions')
+    .getFeeCurrencyAndAmounts as GetFeeCurrencyAndAmounts
+  return getFeeCurrencyAndAmounts(prepareTransactionsResult)
+}
+
+export async function sendPreparedTransactions(prepared: PreparedTransactionsPossible) {
+  const runSaga = require('../redux/store').runSaga as RunSaga
+  const getSerializablePreparedTransactions = require('../viem/preparedTransactionSerialization')
+    .getSerializablePreparedTransactions as GetSerializablePreparedTransactions
+  const sendPreparedTransactions = require('../viem/saga')
+    .sendPreparedTransactions as SendPreparedTransactions
+
+  const result = await runSaga(function* () {
+    const txHashes = yield* call(
+      sendPreparedTransactions,
+      getSerializablePreparedTransactions(prepared.transactions),
+      prepared.feeCurrency.networkId,
+      // We can't really create standby transactions automatically
+      // since we don't have the necessary information
+      // TODO: decide whether we want to expose this to builders
+      prepared.transactions.map(() => () => null)
+    )
+    return txHashes
+  })
+
+  return result
+}

--- a/packages/@divvi/mobile/src/public/prepareTransactions.ts
+++ b/packages/@divvi/mobile/src/public/prepareTransactions.ts
@@ -1,18 +1,12 @@
 // See useWallet for why we don't directly import internal modules, except for the types
-import { call } from 'typed-redux-saga'
 import type { Address, Hex } from 'viem'
-import type { RunSaga, Store } from '../redux/store'
+import type { Store } from '../redux/store'
 import type { FeeCurrenciesSelector } from '../tokens/selectors'
 import type { NetworkId as InternalNetworkId } from '../transactions/types'
 import type {
-  GetFeeCurrencyAndAmounts,
   TransactionRequest as InternalTransactionRequest,
-  PreparedTransactionsPossible,
-  PreparedTransactionsResult,
   PrepareTransactions,
 } from '../viem/prepareTransactions'
-import type { GetSerializablePreparedTransactions } from '../viem/preparedTransactionSerialization'
-import type { SendPreparedTransactions } from '../viem/saga'
 import type { NetworkId } from './types'
 
 export type {
@@ -65,34 +59,5 @@ export async function prepareTransactions({
     baseTransactions: toInternalTransactionRequests(transactionRequests),
     origin: 'framework',
   })
-  return result
-}
-
-export function getFees(prepareTransactionsResult: PreparedTransactionsResult | undefined) {
-  const getFeeCurrencyAndAmounts = require('../viem/prepareTransactions')
-    .getFeeCurrencyAndAmounts as GetFeeCurrencyAndAmounts
-  return getFeeCurrencyAndAmounts(prepareTransactionsResult)
-}
-
-export async function sendPreparedTransactions(prepared: PreparedTransactionsPossible) {
-  const runSaga = require('../redux/store').runSaga as RunSaga
-  const getSerializablePreparedTransactions = require('../viem/preparedTransactionSerialization')
-    .getSerializablePreparedTransactions as GetSerializablePreparedTransactions
-  const sendPreparedTransactions = require('../viem/saga')
-    .sendPreparedTransactions as SendPreparedTransactions
-
-  const result = await runSaga(function* () {
-    const txHashes = yield* call(
-      sendPreparedTransactions,
-      getSerializablePreparedTransactions(prepared.transactions),
-      prepared.feeCurrency.networkId,
-      // We can't really create standby transactions automatically
-      // since we don't have the necessary information
-      // TODO: decide whether we want to expose this to builders
-      prepared.transactions.map(() => () => null)
-    )
-    return txHashes
-  })
-
   return result
 }

--- a/packages/@divvi/mobile/src/public/sendTransactions.test.ts
+++ b/packages/@divvi/mobile/src/public/sendTransactions.test.ts
@@ -1,0 +1,37 @@
+import { mockAccount, mockCeloTokenBalance } from '../../test/values'
+import { getSerializablePreparedTransactions } from '../viem/preparedTransactionSerialization'
+import { sendPreparedTransactions as sendPreparedTransactionsSaga } from '../viem/saga'
+import type { PreparedTransactionsPossible } from './prepareTransactions'
+import { sendTransactions } from './sendTransactions'
+
+jest.mock('../viem/saga')
+
+describe('sendTransactions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(sendPreparedTransactionsSaga).mockReset()
+  })
+
+  it('should correctly send prepared transactions', async () => {
+    const mockTxHashes = ['0x123', '0x456']
+    const mockPrepared = {
+      type: 'possible',
+      transactions: [
+        { to: mockAccount, value: BigInt(1000) },
+        { to: mockAccount, value: BigInt(1000) },
+      ],
+      feeCurrency: mockCeloTokenBalance,
+    } as PreparedTransactionsPossible
+
+    jest.mocked(sendPreparedTransactionsSaga).mockReturnValue(mockTxHashes as any)
+
+    const result = await sendTransactions(mockPrepared as any)
+
+    expect(result).toEqual(mockTxHashes)
+    expect(sendPreparedTransactionsSaga).toHaveBeenCalledWith(
+      getSerializablePreparedTransactions(mockPrepared.transactions),
+      'celo-alfajores',
+      expect.any(Array)
+    )
+  })
+})

--- a/packages/@divvi/mobile/src/public/sendTransactions.ts
+++ b/packages/@divvi/mobile/src/public/sendTransactions.ts
@@ -1,0 +1,25 @@
+import { call } from 'typed-redux-saga'
+import type { RunSaga } from '../redux/store'
+import type { GetSerializablePreparedTransactions } from '../viem/preparedTransactionSerialization'
+import type { SendPreparedTransactions } from '../viem/saga'
+import type { PreparedTransactionsPossible } from './prepareTransactions'
+
+export async function sendTransactions(prepared: PreparedTransactionsPossible) {
+  const runSaga = require('../redux/store').runSaga as RunSaga
+  const getSerializablePreparedTransactions = require('../viem/preparedTransactionSerialization')
+    .getSerializablePreparedTransactions as GetSerializablePreparedTransactions
+  const sendPreparedTransactions = require('../viem/saga')
+    .sendPreparedTransactions as SendPreparedTransactions
+
+  const result = await runSaga(function* () {
+    const txHashes = yield* call(
+      sendPreparedTransactions,
+      getSerializablePreparedTransactions(prepared.transactions),
+      prepared.feeCurrency.networkId,
+      prepared.transactions.map(() => () => null)
+    )
+    return txHashes
+  })
+
+  return result
+}

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -208,3 +208,18 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
     }
   }
 }
+
+// TODO: we'll use this type throughout the framework once we're able to make bigger refactor, eliminating the current NetworkId enum
+export type NetworkId =
+  | 'celo-mainnet'
+  | 'celo-alfajores'
+  | 'ethereum-mainnet'
+  | 'ethereum-sepolia'
+  | 'arbitrum-one'
+  | 'arbitrum-sepolia'
+  | 'op-mainnet'
+  | 'op-sepolia'
+  | 'polygon-pos-mainnet'
+  | 'polygon-pos-amoy'
+  | 'base-mainnet'
+  | 'base-sepolia'

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -223,4 +223,3 @@ export type NetworkId =
   | 'polygon-pos-amoy'
   | 'base-mainnet'
   | 'base-sepolia'
-

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -223,3 +223,4 @@ export type NetworkId =
   | 'polygon-pos-amoy'
   | 'base-mainnet'
   | 'base-sepolia'
+

--- a/packages/@divvi/mobile/src/redux/store.ts
+++ b/packages/@divvi/mobile/src/redux/store.ts
@@ -125,12 +125,18 @@ export const setupStore = (initialState?: ReducersRootState, config = persistCon
   const createdPersistor = persistStore(createdStore)
   sagaMiddleware.run(rootSaga)
 
-  return { store: createdStore, persistor: createdPersistor }
+  return { store: createdStore, persistor: createdPersistor, sagaMiddleware }
 }
 
-const { store, persistor } = setupStore()
+const { store, persistor, sagaMiddleware } = setupStore()
 
-export { persistor, store }
+export type RunSaga = typeof runSaga
+function runSaga<T>(saga: () => Generator<unknown, T, unknown>): Promise<T> {
+  return sagaMiddleware.run(saga).toPromise()
+}
+
+export type Store = typeof store
+export { persistor, runSaga, store }
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch

--- a/packages/@divvi/mobile/src/tokens/selectors.ts
+++ b/packages/@divvi/mobile/src/tokens/selectors.ts
@@ -510,6 +510,7 @@ const feeCurrenciesByNetworkIdSelector = createSelector(
 // for testing
 export const _feeCurrenciesByNetworkIdSelector = feeCurrenciesByNetworkIdSelector
 
+export type FeeCurrenciesSelector = typeof feeCurrenciesSelector
 export const feeCurrenciesSelector = createSelector(
   feeCurrenciesByNetworkIdSelector,
   (_state: RootState, networkId: NetworkId) => networkId,

--- a/packages/@divvi/mobile/src/viem/prepareTransactions.ts
+++ b/packages/@divvi/mobile/src/viem/prepareTransactions.ts
@@ -256,6 +256,7 @@ export async function tryEstimateTransactions(
   return transactions
 }
 
+export type PrepareTransactions = typeof prepareTransactions
 /**
  * Prepare transactions to submit to the blockchain.
  *
@@ -481,6 +482,7 @@ export function prepareSendNativeAssetTransaction(
   })
 }
 
+export type GetFeeCurrencyAndAmounts = typeof getFeeCurrencyAndAmounts
 /**
  * Given prepared transactions, get the fee currency and amounts in decimals
  *

--- a/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.ts
+++ b/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.ts
@@ -41,6 +41,7 @@ export function getSerializablePreparedTransaction(
   return mapBigIntsToStrings(preparedTransaction, bigIntProps)
 }
 
+export type GetSerializablePreparedTransactions = typeof getSerializablePreparedTransactions
 export function getSerializablePreparedTransactions(
   preparedTransactions: TransactionRequest[]
 ): SerializableTransactionRequest[] {

--- a/packages/@divvi/mobile/src/viem/saga.ts
+++ b/packages/@divvi/mobile/src/viem/saga.ts
@@ -17,6 +17,7 @@ import { getTransactionCount } from 'viem/actions'
 
 const TAG = 'viem/saga'
 
+export type SendPreparedTransactions = typeof sendPreparedTransactions
 /**
  * Sends prepared transactions and adds standby transactions to the store.
  * Returns the hashes of the sent transactions. Throws if the transactions fail

--- a/packages/@divvi/mobile/test/RootStateSchema.json
+++ b/packages/@divvi/mobile/test/RootStateSchema.json
@@ -3986,36 +3986,6 @@
         "StandbyTransaction": {
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PendingStandbyTransaction<TokenTransfer>"
-                },
-                {
-                    "$ref": "#/definitions/PendingStandbyTransaction<TokenApproval>"
-                },
-                {
-                    "$ref": "#/definitions/PendingStandbyTransaction<NftTransfer>"
-                },
-                {
-                    "$ref": "#/definitions/PendingStandbyTransaction<DepositOrWithdraw>"
-                },
-                {
-                    "$ref": "#/definitions/PendingStandbyTransaction<EarnWithdraw>"
-                },
-                {
-                    "$ref": "#/definitions/PendingStandbyTransaction<EarnClaimReward>"
-                },
-                {
-                    "$ref": "#/definitions/PendingStandbyTransaction<PendingTokenExchange>"
-                },
-                {
-                    "$ref": "#/definitions/PendingStandbyTransaction<ClaimReward>"
-                },
-                {
-                    "$ref": "#/definitions/PendingStandbyTransaction<EarnDeposit>"
-                },
-                {
-                    "$ref": "#/definitions/PendingStandbyTransaction<EarnSwapDeposit>"
-                },
-                {
                     "additionalProperties": false,
                     "properties": {
                         "block": {
@@ -4681,6 +4651,36 @@
                         "type"
                     ],
                     "type": "object"
+                },
+                {
+                    "$ref": "#/definitions/PendingStandbyTransaction<PendingTokenExchange>"
+                },
+                {
+                    "$ref": "#/definitions/PendingStandbyTransaction<TokenTransfer>"
+                },
+                {
+                    "$ref": "#/definitions/PendingStandbyTransaction<TokenApproval>"
+                },
+                {
+                    "$ref": "#/definitions/PendingStandbyTransaction<NftTransfer>"
+                },
+                {
+                    "$ref": "#/definitions/PendingStandbyTransaction<DepositOrWithdraw>"
+                },
+                {
+                    "$ref": "#/definitions/PendingStandbyTransaction<ClaimReward>"
+                },
+                {
+                    "$ref": "#/definitions/PendingStandbyTransaction<EarnDeposit>"
+                },
+                {
+                    "$ref": "#/definitions/PendingStandbyTransaction<EarnSwapDeposit>"
+                },
+                {
+                    "$ref": "#/definitions/PendingStandbyTransaction<EarnWithdraw>"
+                },
+                {
+                    "$ref": "#/definitions/PendingStandbyTransaction<EarnClaimReward>"
                 }
             ]
         },
@@ -6500,10 +6500,10 @@
         "TokenTransaction": {
             "anyOf": [
                 {
-                    "$ref": "#/definitions/TokenTransfer"
+                    "$ref": "#/definitions/TokenExchange"
                 },
                 {
-                    "$ref": "#/definitions/TokenExchange"
+                    "$ref": "#/definitions/TokenTransfer"
                 },
                 {
                     "$ref": "#/definitions/TokenApproval"
@@ -6515,12 +6515,6 @@
                     "$ref": "#/definitions/DepositOrWithdraw"
                 },
                 {
-                    "$ref": "#/definitions/EarnWithdraw"
-                },
-                {
-                    "$ref": "#/definitions/EarnClaimReward"
-                },
-                {
                     "$ref": "#/definitions/ClaimReward"
                 },
                 {
@@ -6528,6 +6522,12 @@
                 },
                 {
                     "$ref": "#/definitions/EarnSwapDeposit"
+                },
+                {
+                    "$ref": "#/definitions/EarnWithdraw"
+                },
+                {
+                    "$ref": "#/definitions/EarnClaimReward"
                 }
             ]
         },


### PR DESCRIPTION
### Description

This PR introduces a clear two-step transaction flow API for our mobile framework, making it easier for developers to build transparent transaction experiences.
Following the pattern we've implemented throughout the wallet.

### Design approach

The transaction flow is split into two distinct steps, each with its own React hook:

1. `usePrepareTransactions`: Handles transaction preparation
   - Estimates gas and fees
   - Returns preparation status and errors
   - `getFees` can be called to show fee details

2. `useSendTransactions`: Handles transaction signing and sending
   - Takes prepared transaction data
   - Returns sending status and transaction hashes
   - Provides reset functionality for clearing previous send state

This separation:
- Matches the natural user flow (preview then confirm)
- Enables clear error handling at each step
- Allows developers to insert custom UI/logic between preparation and sending
- Makes it easier to show fee estimates before sending

There are also `async` actions that can be called for cases where developers don't want to use React hooks.

Note: in the future we could consider providing pre-made screens / components that work with prepared transactions.

### Example usage

```tsx
// Basic usage
function TransactionFlow() {
  const { prepareTransactions, data: prepared, status: prepareStatus } = usePrepareTransactions()
  const { sendTransactions, data: txHashes, status: sendStatus } = useSendTransactions()

  const handlePrepare = async () => {
    // 1. Prepare
    const prepared = await prepareTransactions({
      networkId,
      transactionRequests: [/* ... */]
    })
  }

  const handleSend = async () => {    
    // 2. Send
    await sendTransactions(prepared)
  }
}
```

See a comprehensive example in #64 

### Alternative considered

I considered combining preparation and sending into a single hook, but decided against it because:
- Two-step flow matches user expectations better
- Separate hooks provide clearer error handling
- More flexibility for custom UI between steps
- Easier to document and understand each step's purpose

The slight increase in API surface is worth it for the clarity and flexibility it provides to developers.

### Test plan

- Updated tests

### Related issues

- Part of RET-1312

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
