### PR TITLE
feat: add option to display actions carousel on tab wallet

### DIFF
--- a/packages/@divvi/mobile/src/earn/EarnHome.test.tsx
+++ b/packages/@divvi/mobile/src/earn/EarnHome.test.tsx
@@ -24,9 +24,6 @@ const defaultConfig: PublicAppConfig = {
   displayName: 'test',
   deepLinkUrlScheme: 'test',
   experimental: {
-    activity: {
-      showActionsCarousel: true,
-    },
     earn: {
       showLearnMore: true,
     },

--- a/packages/@divvi/mobile/src/home/TabHome.tsx
+++ b/packages/@divvi/mobile/src/home/TabHome.tsx
@@ -62,7 +62,7 @@ function TabHome(_props: Props) {
   const showNftReward = canShowNftReward && isFocused && !showNotificationSpotlight
 
   const showZerionTransactionFeed = getFeatureGate(StatsigFeatureGates.SHOW_ZERION_TRANSACTION_FEED)
-  const showActionsCarousel = getAppConfig().experimental?.activity?.showActionsCarousel ?? true
+  const hideActionsCarousel = getAppConfig().experimental?.activity?.hideActionsCarousel ?? false
 
   useEffect(() => {
     dispatch(visitHome())
@@ -128,7 +128,7 @@ function TabHome(_props: Props) {
   ) as React.ReactElement<RefreshControlProps>
 
   const flatListSections = [
-    ...(showActionsCarousel ? [{ key: 'ActionsCarousel', component: <ActionsCarousel /> }] : []),
+    ...(!hideActionsCarousel ? [{ key: 'ActionsCarousel', component: <ActionsCarousel /> }] : []),
     {
       key: 'NotificationBox',
       component: <NotificationBox showOnlyHomeScreenNotifications={true} />,

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -196,6 +196,9 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
       showLearnMore?: boolean
       showSafetyScoreOnPoolCard?: boolean
     }
+    wallet?: {
+      showActionsCarousel?: boolean
+    }
     transactions?: {
       emptyState?: React.ReactElement
     }

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -190,7 +190,7 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
       protectWallet?: boolean
     }
     activity?: {
-      showActionsCarousel?: boolean
+      hideActionsCarousel?: boolean
     }
     earn?: {
       showLearnMore?: boolean

--- a/packages/@divvi/mobile/src/tokens/TabWallet.test.tsx
+++ b/packages/@divvi/mobile/src/tokens/TabWallet.test.tsx
@@ -294,7 +294,7 @@ describe('TabWallet', () => {
   })
 
   it('does not render actions carousel by default', () => {
-    jest.mocked(getDynamicConfigParams).mockReturnValue({ enabled: true })  // Needed for the quick action bar
+    jest.mocked(getDynamicConfigParams).mockReturnValue({ enabled: true }) // Needed for the quick action bar
     const store = createMockStore(storeWithPositions)
 
     const { queryByTestId } = render(

--- a/packages/@divvi/mobile/src/tokens/TabWallet.tsx
+++ b/packages/@divvi/mobile/src/tokens/TabWallet.tsx
@@ -167,7 +167,7 @@ function TabWallet({ navigation, route }: Props) {
           onLayout={handleMeasureNonStickyHeaderHeight}
         >
           <AssetsTokenBalance showInfo={displayPositions} />
-          { showActionsCarousel && <ActionsCarousel key={'ActionsCarousel'} /> }
+          { showActionsCarousel && <ActionsCarousel /> }
         </View>
         <AssetTabBar
           activeTab={activeTab}

--- a/packages/@divvi/mobile/src/tokens/TabWallet.tsx
+++ b/packages/@divvi/mobile/src/tokens/TabWallet.tsx
@@ -10,8 +10,10 @@ import Animated, {
 } from 'react-native-reanimated'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { AssetsEvents } from 'src/analytics/Events'
+import { getAppConfig } from 'src/appConfig'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { AssetsTokenBalance } from 'src/components/TokenBalance'
+import ActionsCarousel from 'src/home/ActionsCarousel'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import useScrollAwareHeader from 'src/navigator/ScrollAwareHeader'
@@ -53,6 +55,7 @@ function TabWallet({ navigation, route }: Props) {
     dappShortcutsEnabled &&
     positionsWithClaimableRewards.length > 0 &&
     activeTab !== AssetTabType.Collectibles
+  const showActionsCarousel = getAppConfig().experimental?.activity?.showActionsCarousel ?? false
 
   const [nonStickyHeaderHeight, setNonStickyHeaderHeight] = useState(0)
   const [listHeaderHeight, setListHeaderHeight] = useState(0)
@@ -164,6 +167,7 @@ function TabWallet({ navigation, route }: Props) {
           onLayout={handleMeasureNonStickyHeaderHeight}
         >
           <AssetsTokenBalance showInfo={displayPositions} />
+          { showActionsCarousel && <ActionsCarousel key={'ActionsCarousel'} /> }
         </View>
         <AssetTabBar
           activeTab={activeTab}

--- a/packages/@divvi/mobile/src/tokens/TabWallet.tsx
+++ b/packages/@divvi/mobile/src/tokens/TabWallet.tsx
@@ -55,7 +55,7 @@ function TabWallet({ navigation, route }: Props) {
     dappShortcutsEnabled &&
     positionsWithClaimableRewards.length > 0 &&
     activeTab !== AssetTabType.Collectibles
-  const showActionsCarousel = getAppConfig().experimental?.activity?.showActionsCarousel ?? false
+  const showActionsCarousel = getAppConfig().experimental?.wallet?.showActionsCarousel ?? false
 
   const [nonStickyHeaderHeight, setNonStickyHeaderHeight] = useState(0)
   const [listHeaderHeight, setListHeaderHeight] = useState(0)

--- a/packages/@divvi/mobile/src/tokens/TabWallet.tsx
+++ b/packages/@divvi/mobile/src/tokens/TabWallet.tsx
@@ -167,7 +167,7 @@ function TabWallet({ navigation, route }: Props) {
           onLayout={handleMeasureNonStickyHeaderHeight}
         >
           <AssetsTokenBalance showInfo={displayPositions} />
-          { showActionsCarousel && <ActionsCarousel /> }
+          {showActionsCarousel && <ActionsCarousel />}
         </View>
         <AssetTabBar
           activeTab={activeTab}

--- a/packages/@divvi/mobile/src/transactions/feed/TransactionFeedV2.tsx
+++ b/packages/@divvi/mobile/src/transactions/feed/TransactionFeedV2.tsx
@@ -244,7 +244,7 @@ export default function TransactionFeedV2() {
   const dispatch = useDispatch()
 
   const showUKCompliantVariant = getFeatureGate(StatsigFeatureGates.SHOW_UK_COMPLIANT_VARIANT)
-  const showActionsCarousel = getAppConfig().experimental?.activity?.showActionsCarousel ?? true
+  const hideActionsCarousel = getAppConfig().experimental?.activity?.hideActionsCarousel ?? false
 
   const allowedNetworkForTransfers = useAllowedNetworksForTransfers()
   const address = useSelector(walletAddressSelector)
@@ -446,7 +446,7 @@ export default function TransactionFeedV2() {
         initialNumToRender={20}
         ListHeaderComponent={
           <>
-            {showActionsCarousel && <ActionsCarousel />}
+            {!hideActionsCarousel && <ActionsCarousel />}
             <NotificationBox showOnlyHomeScreenNotifications={true} />
           </>
         }


### PR DESCRIPTION
### Description

Add the experimental config to allow the wallet tab to the quick actions carousel.

### Test plan

- [x] Tested in CI
- [x] Tested on iOS

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
