### PR TITLE
feat(alchemy): add experimental feature for specifying alchemy keys

### DIFF
--- a/packages/@divvi/mobile/src/config.ts
+++ b/packages/@divvi/mobile/src/config.ts
@@ -20,6 +20,7 @@ export interface ExpectedLaunchArgs {
 // TODO: remove the secrets file and inject secrets another way
 const secretsFile = {}
 const appConfig = getAppConfig()
+const experimentalConfig = appConfig.experimental ?? {}
 const keyOrUndefined = (file: any, secretsKey: any, attribute: any) => {
   if (secretsKey in file) {
     if (attribute in file[secretsKey]) {
@@ -98,28 +99,28 @@ export const WEB3AUTH_CLIENT_ID =
 
 // SECRETS
 export const ALCHEMY_ETHEREUM_API_KEY = keyOrUndefined(
-  secretsFile,
-  DEFAULT_TESTNET,
+  experimentalConfig,
+  'alchemyKeys',
   'ALCHEMY_ETHEREUM_API_KEY'
 )
 export const ALCHEMY_ARBITRUM_API_KEY = keyOrUndefined(
-  secretsFile,
-  DEFAULT_TESTNET,
+  experimentalConfig,
+  'alchemyKeys',
   'ALCHEMY_ARBITRUM_API_KEY'
 )
 export const ALCHEMY_OPTIMISM_API_KEY = keyOrUndefined(
-  secretsFile,
-  DEFAULT_TESTNET,
+  experimentalConfig,
+  'alchemyKeys',
   'ALCHEMY_OPTIMISM_API_KEY'
 )
 export const ALCHEMY_POLYGON_POS_API_KEY = keyOrUndefined(
-  secretsFile,
-  DEFAULT_TESTNET,
+  experimentalConfig,
+  'alchemyKeys',
   'ALCHEMY_POLYGON_POS_API_KEY'
 )
 export const ALCHEMY_BASE_API_KEY = keyOrUndefined(
-  secretsFile,
-  DEFAULT_TESTNET,
+  experimentalConfig,
+  'alchemyKeys',
   'ALCHEMY_BASE_API_KEY'
 )
 

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -185,6 +185,9 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
    */
   experimental?: {
     firebase?: boolean
+    // can copy/paste old alchemy key/secret pairs here
+    // will be replaced by the networks field
+    alchemyKeys?: Record<string, string>
     onboarding?: {
       enableBiometry?: boolean
       protectWallet?: boolean


### PR DESCRIPTION
### Description

I'm adding this to unblock users in the F&F Camp but I assume it will be replaced very soon with the `networks` config.

### Use

Just copy/paste the alchemy secrets from valora. Ex:

```
experimental: {
    alchemyKeys: {
      "ALCHEMY_ETHEREUM_API_KEY": "<key>",
      "ALCHEMY_ARBITRUM_API_KEY": "<key>",
      "ALCHEMY_OPTIMISM_API_KEY": "<key>",
      "ALCHEMY_POLYGON_POS_API_KEY": "<key>",
      "ALCHEMY_BASE_API_KEY": "<key>",
    }
  }
```