### PR TITLE
feat: public api for getting viem public and wallet clients

### DIFF
--- a/packages/@divvi/mobile/src/public/getPublicClient.test.ts
+++ b/packages/@divvi/mobile/src/public/getPublicClient.test.ts
@@ -1,0 +1,13 @@
+import { getPublicClient } from './getPublicClient'
+
+describe('getPublicClient', () => {
+  it('should return the correct public client', () => {
+    const publicClient = getPublicClient({ networkId: 'celo-alfajores' })
+    expect(publicClient).toBeDefined()
+  })
+
+  it('should throw an error if the networkId is not yet supported', () => {
+    // Tests only use testnet networks, in the future we'll be able to remove this check
+    expect(() => getPublicClient({ networkId: 'celo-mainnet' })).toThrow()
+  })
+})

--- a/packages/@divvi/mobile/src/public/getPublicClient.ts
+++ b/packages/@divvi/mobile/src/public/getPublicClient.ts
@@ -1,0 +1,22 @@
+// See useWallet for why we don't directly import internal modules, except for the types
+import type { StaticPublicClient } from '../viem'
+import type { NetworkConfig, NetworkIdToNetwork } from '../web3/networkConfig'
+import type { NetworkId } from './types'
+
+// TODO: return a chain typed client
+export function getPublicClient({ networkId }: { networkId: NetworkId }) {
+  const publicClient = require('../viem').publicClient as StaticPublicClient
+  const networkIdToNetwork = require('../web3/networkConfig')
+    .networkIdToNetwork as NetworkIdToNetwork
+  const networkConfig = require('../web3/networkConfig').default as NetworkConfig
+
+  const network = networkIdToNetwork[networkId]
+
+  // TODO: remove this check once we have a public client for all networkIds
+  // This is a limitation of the current networkConfig
+  if (networkConfig.networkToNetworkId[network] !== networkId) {
+    throw new Error(`${networkId} can't yet be used`)
+  }
+
+  return publicClient[network]
+}

--- a/packages/@divvi/mobile/src/public/getWalletClient.test.ts
+++ b/packages/@divvi/mobile/src/public/getWalletClient.test.ts
@@ -1,0 +1,24 @@
+import { celoAlfajores } from 'viem/chains'
+import { getViemWallet } from '../web3/contracts'
+import { getWalletClient } from './getWalletClient'
+
+jest.mock('../web3/contracts')
+
+describe('getWalletClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.mocked(getViemWallet).mockReturnValue({} as any)
+  })
+
+  it('should return the correct wallet client', async () => {
+    const walletClient = await getWalletClient({ networkId: 'celo-alfajores' })
+    expect(walletClient).toBeDefined()
+    expect(getViemWallet).toHaveBeenCalledWith(celoAlfajores)
+  })
+
+  it('should throw an error if the networkId is not yet supported', async () => {
+    // Tests only use testnet networks, in the future we'll be able to remove this check
+    await expect(getWalletClient({ networkId: 'celo-mainnet' })).rejects.toThrow()
+  })
+})

--- a/packages/@divvi/mobile/src/public/getWalletClient.ts
+++ b/packages/@divvi/mobile/src/public/getWalletClient.ts
@@ -1,0 +1,29 @@
+// See useWallet for why we don't directly import internal modules, except for the types
+import { call } from 'typed-redux-saga'
+import type { RunSaga } from '../redux/store'
+import type { GetViemWallet } from '../web3/contracts'
+import type { NetworkConfig, NetworkIdToNetwork } from '../web3/networkConfig'
+import type { NetworkId } from './types'
+
+// TODO: return a chain typed client
+export async function getWalletClient({ networkId }: { networkId: NetworkId }) {
+  const runSaga = require('../redux/store').runSaga as RunSaga
+  const getViemWallet = require('../web3/contracts').getViemWallet as GetViemWallet
+  const networkIdToNetwork = require('../web3/networkConfig')
+    .networkIdToNetwork as NetworkIdToNetwork
+  const networkConfig = require('../web3/networkConfig').default as NetworkConfig
+
+  const network = networkIdToNetwork[networkId]
+
+  // TODO: remove this check once we have a wallet client for all networkIds
+  // This is a limitation of the current networkConfig
+  if (networkConfig.networkToNetworkId[network] !== networkId) {
+    throw new Error(`${networkId} can't yet be used`)
+  }
+
+  const result = await runSaga(function* () {
+    return yield* call(getViemWallet, networkConfig.viemChain[network])
+  })
+
+  return result
+}

--- a/packages/@divvi/mobile/src/public/hooks/usePublicClient.test.ts
+++ b/packages/@divvi/mobile/src/public/hooks/usePublicClient.test.ts
@@ -1,0 +1,24 @@
+import { renderHook } from '@testing-library/react-native'
+import { getPublicClient } from '../getPublicClient'
+import { usePublicClient } from './usePublicClient'
+
+// Mock the getPublicClient function
+jest.mock('../getPublicClient')
+
+describe('usePublicClient', () => {
+  const mockPublicClient = {} as any
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.clearAllMocks()
+    // Setup the mock return value
+    jest.mocked(getPublicClient).mockReturnValue(mockPublicClient)
+  })
+
+  it('should return public client for the given networkId', () => {
+    const { result } = renderHook(() => usePublicClient({ networkId: 'celo-alfajores' }))
+
+    expect(getPublicClient).toHaveBeenCalledWith({ networkId: 'celo-alfajores' })
+    expect(result.current).toBe(mockPublicClient)
+  })
+})

--- a/packages/@divvi/mobile/src/public/hooks/usePublicClient.ts
+++ b/packages/@divvi/mobile/src/public/hooks/usePublicClient.ts
@@ -1,0 +1,7 @@
+import { getPublicClient } from '../getPublicClient'
+import { NetworkId } from '../types'
+
+export function usePublicClient({ networkId }: { networkId: NetworkId }) {
+  const publicClient = getPublicClient({ networkId })
+  return publicClient
+}

--- a/packages/@divvi/mobile/src/public/hooks/useWalletClient.test.ts
+++ b/packages/@divvi/mobile/src/public/hooks/useWalletClient.test.ts
@@ -1,0 +1,35 @@
+import { renderHook, waitFor } from '@testing-library/react-native'
+import { getWalletClient } from '../getWalletClient'
+import { useWalletClient } from './useWalletClient'
+
+jest.mock('../getWalletClient')
+const mockGetWalletClient = jest.mocked(getWalletClient)
+
+// This test focuses on the key integration points of the hook, avoiding testing react-async-hook which is already tested
+describe('useWalletClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetWalletClient.mockReset()
+  })
+
+  it('should get wallet client and expose result', async () => {
+    const mockWalletClient = {} as any
+    mockGetWalletClient.mockResolvedValueOnce(mockWalletClient)
+
+    const { result } = renderHook(() => useWalletClient({ networkId: 'celo-alfajores' }))
+
+    await waitFor(() => expect(result.current.data).toEqual(mockWalletClient))
+    expect(mockGetWalletClient).toHaveBeenCalledTimes(1)
+    expect(result.current.status).toEqual('success')
+  })
+
+  it('should expose errors when getting wallet client fails', async () => {
+    const mockError = new Error('Failed to get wallet client')
+    mockGetWalletClient.mockRejectedValueOnce(mockError)
+
+    const { result } = renderHook(() => useWalletClient({ networkId: 'celo-alfajores' }))
+
+    await waitFor(() => expect(result.current.error).toBe(mockError))
+    expect(result.current.status).toEqual('error')
+  })
+})

--- a/packages/@divvi/mobile/src/public/hooks/useWalletClient.ts
+++ b/packages/@divvi/mobile/src/public/hooks/useWalletClient.ts
@@ -1,0 +1,24 @@
+import { useAsync } from 'react-async-hook'
+
+import { useMemo } from 'react'
+import { getWalletClient } from '../getWalletClient'
+import { NetworkId } from '../types'
+import { toAsyncStatus } from './toAsyncStatus'
+
+export function useWalletClient({ networkId }: { networkId: NetworkId }) {
+  const params = useMemo(
+    () => ({
+      networkId,
+    }),
+    [networkId]
+  )
+  const asyncCallback = useAsync(getWalletClient, [params])
+
+  return {
+    status: toAsyncStatus(asyncCallback.status),
+    error: asyncCallback.error,
+    data: asyncCallback.result,
+    refresh: asyncCallback.execute,
+    reset: asyncCallback.reset,
+  }
+}

--- a/packages/@divvi/mobile/src/public/index.ts
+++ b/packages/@divvi/mobile/src/public/index.ts
@@ -7,9 +7,13 @@
  */
 export { createApp } from './createApp'
 export { getFees } from './getFees'
+export { getPublicClient } from './getPublicClient'
+export { getWalletClient } from './getWalletClient'
 export { usePrepareTransactions } from './hooks/usePrepareTransactions'
+export { usePublicClient } from './hooks/usePublicClient'
 export { useSendTransactions } from './hooks/useSendTransactions'
 export { useWallet } from './hooks/useWallet'
+export { useWalletClient } from './hooks/useWalletClient'
 export {
   prepareTransactions,
   type PreparedTransactionsNeedDecreaseSpendAmountForGas,

--- a/packages/@divvi/mobile/src/viem/index.ts
+++ b/packages/@divvi/mobile/src/viem/index.ts
@@ -54,6 +54,7 @@ export const appViemTransports = {
   [Network.Arbitrum]: http(networkConfig.internalRpcUrl.arbitrum),
 } satisfies Record<(typeof INTERNAL_RPC_SUPPORTED_NETWORKS)[number], Transport>
 
+export type StaticPublicClient = typeof publicClient
 export const publicClient = {
   [Network.Celo]: createPublicClient({
     chain: networkConfig.viemChain.celo,

--- a/packages/@divvi/mobile/src/web3/contracts.ts
+++ b/packages/@divvi/mobile/src/web3/contracts.ts
@@ -49,6 +49,7 @@ export function getKeychainAccounts(): Promise<KeychainAccounts> {
   return initKeychainAccountsPromise
 }
 
+export type GetViemWallet = typeof getViemWallet
 // This code assumes that the account for walletAddress already exists in the Keychain
 // which is a responsibility currently handled by KeychainAccounts
 export function* getViemWallet(chain: Chain, useAppTransport?: boolean) {

--- a/packages/@divvi/mobile/src/web3/networkConfig.ts
+++ b/packages/@divvi/mobile/src/web3/networkConfig.ts
@@ -25,7 +25,7 @@ export enum Testnets {
   mainnet = 'mainnet',
 }
 
-interface NetworkConfig {
+export interface NetworkConfig {
   blockchainApiUrl: string
   hooksApiUrl: string
   sentryTracingUrls: string[]


### PR DESCRIPTION
### Description

This PR introduces a public API for accessing Viem public and wallet clients, inspired by [wagmi](https://wagmi.sh/)'s approach. This foundation will enable builders to interact with blockchain networks more directly when needed.

The clients are the same used internally (pre-configured RPC URLs, and connected to the wallet account from the keychain).

### Example usage

```tsx
// Using React hooks
const publicClient = usePublicClient({ networkId: 'celo-mainnet' })
const { data: walletClient } = useWalletClient({ networkId: 'celo-mainnet' })

// Using utility functions directly
const publicClient = getPublicClient({ networkId: 'celo-mainnet' })
const walletClient = await getWalletClient({ networkId: 'celo-mainnet' })
```

### Test plan

- Updated tests

### Related issues

- Part of RET-1312

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
