### PR TITLE
feat: public api for unlocking the account

### DIFF
--- a/packages/@divvi/mobile/src/public/index.ts
+++ b/packages/@divvi/mobile/src/public/index.ts
@@ -24,3 +24,4 @@ export {
 } from './prepareTransactions'
 export { sendTransactions } from './sendTransactions'
 export { type NetworkId, type PublicAppConfig } from './types'
+export { unlockAccount, type UnlockResult } from './unlockAccount'

--- a/packages/@divvi/mobile/src/public/unlockAccount.test.ts
+++ b/packages/@divvi/mobile/src/public/unlockAccount.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable require-yield */
 import { mockAccount } from 'test/values'
 import {
   UnlockResult as InternalUnlockResult,

--- a/packages/@divvi/mobile/src/public/unlockAccount.test.ts
+++ b/packages/@divvi/mobile/src/public/unlockAccount.test.ts
@@ -1,0 +1,78 @@
+import { mockAccount } from 'test/values'
+import {
+  UnlockResult as InternalUnlockResult,
+  unlockAccount as unlockAccountSaga,
+} from '../web3/saga'
+import { walletAddressSelector } from '../web3/selectors'
+import { unlockAccount } from './unlockAccount'
+
+jest.mock('../web3/selectors', () => ({
+  ...jest.requireActual('../web3/selectors'),
+  walletAddressSelector: jest.fn(),
+}))
+jest.mock('../web3/saga', () => ({
+  ...jest.requireActual('../web3/saga'),
+  unlockAccount: jest.fn(),
+}))
+
+const mockWalletSelector = jest.mocked(walletAddressSelector)
+const mockUnlockSaga = jest.mocked(unlockAccountSaga)
+
+describe('unlockAccount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Set default mock values
+    mockWalletSelector.mockReturnValue(mockAccount)
+    mockUnlockSaga.mockImplementation(function* () {
+      return InternalUnlockResult.SUCCESS
+    })
+  })
+
+  it('should return success when unlock is successful', async () => {
+    mockUnlockSaga.mockImplementation(function* () {
+      return InternalUnlockResult.SUCCESS
+    })
+
+    const result = await unlockAccount()
+    expect(result).toBe('success')
+    expect(mockUnlockSaga).toHaveBeenCalledWith(mockAccount)
+  })
+
+  it('should return failure when unlock fails', async () => {
+    mockUnlockSaga.mockImplementation(function* () {
+      return InternalUnlockResult.FAILURE
+    })
+
+    const result = await unlockAccount()
+    expect(result).toBe('failure')
+    expect(mockUnlockSaga).toHaveBeenCalledWith(mockAccount)
+  })
+
+  it('should return canceled when unlock is canceled', async () => {
+    mockUnlockSaga.mockImplementation(function* () {
+      return InternalUnlockResult.CANCELED
+    })
+
+    const result = await unlockAccount()
+    expect(result).toBe('canceled')
+    expect(mockUnlockSaga).toHaveBeenCalledWith(mockAccount)
+  })
+
+  it('should return failure when saga throws an error', async () => {
+    mockUnlockSaga.mockImplementation(function* () {
+      throw new Error('Some error')
+    })
+
+    const result = await unlockAccount()
+    expect(result).toBe('failure')
+    expect(mockUnlockSaga).toHaveBeenCalledWith(mockAccount)
+  })
+
+  it('should return failure when no wallet address is found', async () => {
+    mockWalletSelector.mockReturnValue(null)
+
+    const result = await unlockAccount()
+    expect(result).toBe('failure')
+    expect(mockUnlockSaga).not.toHaveBeenCalled()
+  })
+})

--- a/packages/@divvi/mobile/src/public/unlockAccount.ts
+++ b/packages/@divvi/mobile/src/public/unlockAccount.ts
@@ -1,0 +1,43 @@
+// See useWallet for why we don't directly import internal modules, except for the types
+import { call, select } from 'typed-redux-saga'
+import type { RunSaga } from '../redux/store'
+import type { UnlockResultType as InternalUnlockResultType, UnlockAccount } from '../web3/saga'
+import type { WalletAddressSelector } from '../web3/selectors'
+
+export type UnlockResult =
+  /** unlocked account successfully */
+  | 'success'
+  /** failure while unlocking account */
+  | 'failure'
+  /** user canceled */
+  | 'canceled'
+
+export async function unlockAccount(): Promise<UnlockResult> {
+  const runSaga = require('../redux/store').runSaga as RunSaga
+  const unlockAccount = require('../web3/saga').unlockAccount as UnlockAccount
+  const InternalUnlockResult = require('../web3/saga').UnlockResult as InternalUnlockResultType
+  const walletAddressSelector = require('../web3/selectors')
+    .walletAddressSelector as WalletAddressSelector
+
+  const result = await runSaga(function* () {
+    const address = yield* select(walletAddressSelector)
+    if (!address) {
+      throw new Error('No wallet address found')
+    }
+    return yield* call(unlockAccount, address)
+  }).catch((error) => {
+    return InternalUnlockResult.FAILURE
+  })
+
+  switch (result) {
+    case InternalUnlockResult.SUCCESS:
+      return 'success'
+    case InternalUnlockResult.FAILURE:
+      return 'failure'
+    case InternalUnlockResult.CANCELED:
+      return 'canceled'
+    default:
+      const exhaustiveCheck: never = result
+      return exhaustiveCheck
+  }
+}

--- a/packages/@divvi/mobile/src/web3/saga.ts
+++ b/packages/@divvi/mobile/src/web3/saga.ts
@@ -150,12 +150,14 @@ export function* getWalletAddress() {
 // This needs to be refactored and removed since the name is misleading.
 export const getAccount = getWalletAddress
 
+export type UnlockResultType = typeof UnlockResult
 export enum UnlockResult {
   SUCCESS,
   FAILURE,
   CANCELED,
 }
 
+export type UnlockAccount = typeof unlockAccount
 export function* unlockAccount(account: string, force: boolean = false) {
   Logger.debug(TAG + '@unlockAccount', `Unlocking account: ${account}`)
 


### PR DESCRIPTION
### Description

This PR introduces a public API for unlocking the wallet account.
This is needed for any wallet action that requires signing.

The public `unlockAccount()` function returns a Promise that resolves to one of three states:
- `success` - Account was successfully unlocked
- `failure` - Failed to unlock the account
- `canceled` - User canceled the unlock operation

### Example usage
```tsx
const result = await unlockAccount();
if (result === 'success') {
  // Account unlocked successfully
}
```

### Test plan

- Updated tests

### Related issues

- Part of RET-1312

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
