### PR TITLE
feat: public api for navigating to specific and custom screens

### DIFF
--- a/apps/example/index.tsx
+++ b/apps/example/index.tsx
@@ -51,7 +51,7 @@ const App = createApp({
           defaultTabs.discover,
           defaultTabs.earn,
           {
-            name: 'playground',
+            name: 'Playground',
             component: PlaygroundScreen,
             // TODO: add icon
             icon: () => null,
@@ -63,7 +63,12 @@ const App = createApp({
     },
     custom: (Screen) => (
       <>
-        <Screen name="CustomScreen" component={CustomScreen} options={{ headerShown: true }} />
+        <Screen
+          name="CustomScreen"
+          component={CustomScreen}
+          // TODO: make custom screens use our custom back button
+          options={{ headerBackVisible: true, headerShown: true }}
+        />
       </>
     ),
   },

--- a/apps/example/screens/CustomScreen.tsx
+++ b/apps/example/screens/CustomScreen.tsx
@@ -1,12 +1,14 @@
 import { useWallet } from '@divvi/mobile'
 import React from 'react'
 import { FlatList, StyleSheet, Text, View } from 'react-native'
+import { RootStackScreenProps } from './types'
 
-export default function CustomScreen() {
+export default function CustomScreen({ route }: RootStackScreenProps<'CustomScreen'>) {
   const { address, tokens } = useWallet()
 
   return (
     <View style={styles.container}>
+      <Text style={styles.text}>route.params: {JSON.stringify(route.params)}</Text>
       <View style={styles.walletAddressContainer}>
         <Text style={[styles.text, styles.title]}>Wallet address:</Text>
         <Text style={styles.text}>{address}</Text>

--- a/apps/example/screens/PlaygroundScreen.tsx
+++ b/apps/example/screens/PlaygroundScreen.tsx
@@ -90,6 +90,11 @@ export default function PlaygroundScreen(_props: RootStackScreenProps<'Playgroun
             onPress: () => navigate('Swap', { fromTokenId: 'celo-mainnet:native' }),
           },
           { label: 'Add', onPress: () => navigate('Add') },
+          {
+            label: 'Add with tokenId',
+            onPress: () => navigate('Add', { tokenId: 'celo-mainnet:native' }),
+          },
+          { label: 'Withdraw', onPress: () => navigate('Withdraw') },
           { label: 'Tab Wallet', onPress: () => navigate('TabWallet') },
           {
             label: 'Custom Screen',

--- a/apps/example/screens/PlaygroundScreen.tsx
+++ b/apps/example/screens/PlaygroundScreen.tsx
@@ -1,9 +1,24 @@
-import { getFees, usePrepareTransactions, useSendTransactions, useWallet } from '@divvi/mobile'
+import {
+  getFees,
+  navigate,
+  usePrepareTransactions,
+  useSendTransactions,
+  useWallet,
+} from '@divvi/mobile'
 import React, { useEffect, useState } from 'react'
-import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
 import { Address, parseEther } from 'viem'
+import { RootStackScreenProps } from './types'
 
-export default function PlaygroundScreen() {
+export default function PlaygroundScreen(_props: RootStackScreenProps<'Playground'>) {
   const { address } = useWallet()
 
   const [amount, setAmount] = useState('')
@@ -59,10 +74,37 @@ export default function PlaygroundScreen() {
   const fees = getFees(prepared)
 
   return (
-    <View style={styles.container}>
+    <ScrollView style={styles.container}>
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Wallet</Text>
         <Text>Address: {address}</Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Navigate</Text>
+        {[
+          { label: 'Send', onPress: () => navigate('Send') },
+          { label: 'Receive', onPress: () => navigate('Receive') },
+          {
+            label: 'Swap',
+            onPress: () => navigate('Swap', { fromTokenId: 'celo-mainnet:native' }),
+          },
+          { label: 'Add', onPress: () => navigate('Add') },
+          { label: 'Tab Wallet', onPress: () => navigate('TabWallet') },
+          {
+            label: 'Custom Screen',
+            onPress: () => navigate('CustomScreen', { someParam: 'test' }),
+          },
+        ].map((item) => (
+          <Pressable
+            key={item.label}
+            onPress={item.onPress}
+            style={({ pressed }) => [styles.navButton, pressed && styles.navButtonPressed]}
+          >
+            <Text style={styles.navButtonText}>{item.label}</Text>
+            <Text style={styles.navArrow}>›</Text>
+          </Pressable>
+        ))}
       </View>
 
       <View style={styles.section}>
@@ -161,7 +203,7 @@ export default function PlaygroundScreen() {
           </View>
         )}
       </View>
-    </View>
+    </ScrollView>
   )
 }
 
@@ -271,5 +313,26 @@ const styles = StyleSheet.create({
   warningText: {
     fontSize: 13,
     color: '#9a3412',
+  },
+  navButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: '#f8fafc',
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  navButtonPressed: {
+    backgroundColor: '#f1f5f9',
+  },
+  navButtonText: {
+    fontSize: 16,
+    color: '#334155',
+  },
+  navArrow: {
+    fontSize: 20,
+    color: '#64748b',
   },
 })

--- a/apps/example/screens/types.ts
+++ b/apps/example/screens/types.ts
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps, StackParamList } from '@divvi/mobile'
 
-export type RootStackParamList = StackParamList & {
+type RootStackParamList = StackParamList & {
   Playground: undefined
   CustomScreen: {
     someParam: string

--- a/apps/example/screens/types.ts
+++ b/apps/example/screens/types.ts
@@ -1,0 +1,20 @@
+import { NativeStackScreenProps, StackParamList } from '@divvi/mobile'
+
+export type RootStackParamList = StackParamList & {
+  Playground: undefined
+  CustomScreen: {
+    someParam: string
+  }
+}
+
+export type RootStackScreenProps<T extends keyof RootStackParamList> = NativeStackScreenProps<
+  RootStackParamList,
+  T
+>
+
+// This allows type-safe navigation to known and custom screens using the `navigate` function from `@divvi/mobile`
+declare global {
+  namespace DivviNavigation {
+    interface RootParamList extends RootStackParamList {}
+  }
+}

--- a/packages/@divvi/mobile/src/fiatExchanges/types.ts
+++ b/packages/@divvi/mobile/src/fiatExchanges/types.ts
@@ -24,6 +24,7 @@ export interface ProviderSelectionAnalyticsData {
   networkId: string | undefined
 }
 
+export type FiatExchangeFlowType = typeof FiatExchangeFlow
 export enum FiatExchangeFlow {
   CashIn = 'CashIn',
   CashOut = 'CashOut',

--- a/packages/@divvi/mobile/src/fiatExchanges/types.ts
+++ b/packages/@divvi/mobile/src/fiatExchanges/types.ts
@@ -31,6 +31,7 @@ export enum FiatExchangeFlow {
   Spend = 'Spend',
 }
 
+export type CICOFlowType = typeof CICOFlow
 export enum CICOFlow {
   CashIn = 'CashIn',
   CashOut = 'CashOut',

--- a/packages/@divvi/mobile/src/navigator/NavigationService.ts
+++ b/packages/@divvi/mobile/src/navigator/NavigationService.ts
@@ -97,6 +97,7 @@ export type NavigateParams<RouteName extends keyof StackParamList> =
     ? [RouteName] | [RouteName, StackParamList[RouteName]]
     : [RouteName, StackParamList[RouteName]]
 
+export type Navigate = typeof navigate
 export function navigate<RouteName extends keyof StackParamList>(
   ...args: NavigateParams<RouteName>
 ) {

--- a/packages/@divvi/mobile/src/navigator/Screens.tsx
+++ b/packages/@divvi/mobile/src/navigator/Screens.tsx
@@ -1,3 +1,4 @@
+export type ScreensType = typeof Screens
 export enum Screens {
   AccountKeyEducation = 'AccountKeyEducation',
   AccounSetupFailureScreen = 'AccounSetupFailureScreen',

--- a/packages/@divvi/mobile/src/public/index.ts
+++ b/packages/@divvi/mobile/src/public/index.ts
@@ -14,6 +14,7 @@ export { usePublicClient } from './hooks/usePublicClient'
 export { useSendTransactions } from './hooks/useSendTransactions'
 export { useWallet } from './hooks/useWallet'
 export { useWalletClient } from './hooks/useWalletClient'
+export { navigate, type NativeStackScreenProps, type StackParamList } from './navigate'
 export {
   prepareTransactions,
   type PreparedTransactionsNeedDecreaseSpendAmountForGas,

--- a/packages/@divvi/mobile/src/public/navigate.test.ts
+++ b/packages/@divvi/mobile/src/public/navigate.test.ts
@@ -21,11 +21,14 @@ mockStore.getState.mockImplementation(() =>
   })
 )
 
+// Note: when adding a new public route, add a test for it only if it's a non trivial mapping to an internal screen
 describe('navigate', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
+  // This is a sanity check to ensure that the navigate function is type-safe
+  // Using a couple of examples is enough.
   it('should type check navigation parameters', () => {
     // These should compile without type errors
     navigate('Swap')

--- a/packages/@divvi/mobile/src/public/navigate.test.ts
+++ b/packages/@divvi/mobile/src/public/navigate.test.ts
@@ -50,6 +50,9 @@ describe('navigate', () => {
 
     // @ts-expect-error - Extra invalid parameter
     navigate('Swap', { fromTokenId: 'token1', invalidParam: 'foo' })
+
+    // Just to have an assertion and avoid linting error
+    expect(mockInternalNavigate).toHaveBeenCalled()
   })
 
   it('should allow navigation to custom screens', () => {

--- a/packages/@divvi/mobile/src/public/navigate.test.ts
+++ b/packages/@divvi/mobile/src/public/navigate.test.ts
@@ -1,0 +1,69 @@
+import { navigate } from './navigate'
+
+// Mock the required internal modules
+jest.mock('../navigator/NavigationService', () => ({
+  navigate: jest.fn(),
+}))
+
+const mockInternalNavigate = require('../navigator/NavigationService').navigate
+
+describe('navigate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should navigate to swap screen without params', () => {
+    navigate('Swap')
+
+    expect(mockInternalNavigate).toHaveBeenCalledWith('SwapScreenWithBack', undefined)
+  })
+
+  it('should navigate to swap screen with valid params', () => {
+    navigate('Swap', {
+      fromTokenId: 'token1',
+      toTokenId: 'token2',
+      toTokenNetworkId: 'celo-mainnet',
+    })
+
+    expect(mockInternalNavigate).toHaveBeenCalledWith('SwapScreenWithBack', {
+      fromTokenId: 'token1',
+      toTokenId: 'token2',
+      toTokenNetworkId: 'celo-mainnet',
+    })
+  })
+
+  it('should type check navigation parameters', () => {
+    // These should compile without type errors
+    navigate('Swap')
+    navigate('Swap', undefined)
+    navigate('Swap', {
+      fromTokenId: 'token1',
+    })
+    navigate('Swap', {
+      fromTokenId: 'token1',
+      toTokenId: 'token2',
+      toTokenNetworkId: 'celo-mainnet',
+    })
+
+    // @ts-expect-error - Invalid parameter
+    navigate('Swap', { invalidParam: 'foo' })
+
+    // @ts-expect-error - Extra invalid parameter
+    navigate('Swap', { fromTokenId: 'token1', invalidParam: 'foo' })
+  })
+
+  it('should allow navigation to custom screens', () => {
+    // Using type assertion to simulate a custom screen
+    navigate('CustomScreen' as any)
+
+    expect(mockInternalNavigate).toHaveBeenCalledWith('CustomScreen', undefined)
+  })
+
+  it('should allow navigation to custom screens with params', () => {
+    navigate('CustomScreenWithParams' as any, { customParam: 'test' } as any)
+
+    expect(mockInternalNavigate).toHaveBeenCalledWith('CustomScreenWithParams', {
+      customParam: 'test',
+    })
+  })
+})

--- a/packages/@divvi/mobile/src/public/navigate.ts
+++ b/packages/@divvi/mobile/src/public/navigate.ts
@@ -9,7 +9,7 @@ import type { LoggerType } from '../utils/Logger'
 import type { NetworkConfig } from '../web3/networkConfig'
 import type { NetworkId } from './types'
 
-const TAG = 'Navigate'
+const TAG = 'public/navigate'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/@divvi/mobile/src/public/navigate.ts
+++ b/packages/@divvi/mobile/src/public/navigate.ts
@@ -89,6 +89,7 @@ export function navigate(...[routeName, params]: NavigateArgs): void {
         })
         const tokenInfo = params ? tokens[params.tokenId] : undefined
         if (tokenInfo && tokenInfo.isCashInEligible) {
+          // TODO: we should refactor FiatExchangeAmount so it can accept just a tokenId, without the need for the tokenSymbol
           internalNavigate(Screens.FiatExchangeAmount, {
             tokenId: params.tokenId,
             flow: CICOFlow.CashIn,

--- a/packages/@divvi/mobile/src/public/navigate.ts
+++ b/packages/@divvi/mobile/src/public/navigate.ts
@@ -33,7 +33,7 @@ export type StackParamList = {
 
 export type { NativeStackScreenProps } from '@react-navigation/native-stack'
 
-export type NavigateArgs = {
+type NavigateArgs = {
   [RouteName in keyof DivviNavigation.RootParamList]: undefined extends DivviNavigation.RootParamList[RouteName]
     ? [RouteName] | [RouteName, DivviNavigation.RootParamList[RouteName]]
     : [RouteName, DivviNavigation.RootParamList[RouteName]]

--- a/packages/@divvi/mobile/src/public/navigate.ts
+++ b/packages/@divvi/mobile/src/public/navigate.ts
@@ -1,0 +1,94 @@
+// See useWallet for why we don't directly import internal modules, except for the types
+import type { FiatExchangeFlowType } from '../fiatExchanges/types'
+import type { Navigate } from '../navigator/NavigationService'
+import type { ScreensType } from '../navigator/Screens'
+import type { NetworkId as InternalNetworkId } from '../transactions/types'
+import type { NetworkId } from './types'
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace DivviNavigation {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface RootParamList extends StackParamList {}
+  }
+}
+
+export type StackParamList = {
+  Send: undefined
+  Receive: undefined
+  Swap:
+    | {
+        fromTokenId?: string
+        toTokenId?: string
+        toTokenNetworkId?: NetworkId
+      }
+    | undefined
+  Add: undefined
+  Withdraw: undefined
+  TabWallet: undefined
+  TabActivity: undefined
+  TabEarn: undefined
+  TabDiscover: undefined
+}
+
+export type { NativeStackScreenProps } from '@react-navigation/native-stack'
+
+export type NavigateArgs = {
+  [RouteName in keyof DivviNavigation.RootParamList]: undefined extends DivviNavigation.RootParamList[RouteName]
+    ? [RouteName] | [RouteName, DivviNavigation.RootParamList[RouteName]]
+    : [RouteName, DivviNavigation.RootParamList[RouteName]]
+}[keyof DivviNavigation.RootParamList]
+
+export function navigate(...[routeName, params]: NavigateArgs): void {
+  const internalNavigate = require('../navigator/NavigationService').navigate as Navigate
+  const Screens = require('../navigator/Screens').Screens as ScreensType
+  const FiatExchangeFlow = require('../fiatExchanges/types')
+    .FiatExchangeFlow as FiatExchangeFlowType
+
+  switch (routeName) {
+    case 'Send':
+      internalNavigate(Screens.SendSelectRecipient)
+      break
+    case 'Receive':
+      internalNavigate(Screens.QRNavigator, {
+        screen: Screens.QRCode,
+      })
+      break
+    case 'Swap':
+      internalNavigate(
+        Screens.SwapScreenWithBack,
+        params
+          ? {
+              fromTokenId: params.fromTokenId,
+              toTokenId: params.toTokenId,
+              toTokenNetworkId: params.toTokenNetworkId as InternalNetworkId,
+            }
+          : undefined
+      )
+      break
+    case 'Add':
+      internalNavigate(Screens.FiatExchangeCurrencyBottomSheet, { flow: FiatExchangeFlow.CashIn })
+      break
+    case 'Withdraw':
+      internalNavigate(Screens.WithdrawSpend)
+      break
+    case 'TabWallet':
+      internalNavigate(Screens.TabWallet)
+      break
+    case 'TabActivity':
+      internalNavigate(Screens.TabHome)
+      break
+    case 'TabEarn':
+      internalNavigate(Screens.TabEarn)
+      break
+    case 'TabDiscover':
+      internalNavigate(Screens.TabDiscover)
+      break
+    default:
+      const exhaustiveCheck: never = routeName
+      // This handles custom defined screens
+      // Though also allows navigating to internal screens...
+      internalNavigate(routeName, params)
+      return exhaustiveCheck
+  }
+}

--- a/packages/@divvi/mobile/src/tokens/selectors.ts
+++ b/packages/@divvi/mobile/src/tokens/selectors.ts
@@ -88,6 +88,7 @@ type TokensByIdArgs =
       includePositionTokens?: boolean
     }
 
+export type TokensByIdSelector = typeof tokensByIdSelector
 export const tokensByIdSelector = createSelector(
   [
     (state: RootState) => state.tokens.tokenBalances,

--- a/packages/@divvi/mobile/src/utils/Logger.ts
+++ b/packages/@divvi/mobile/src/utils/Logger.ts
@@ -300,4 +300,5 @@ class Logger {
   }
 }
 
+export type LoggerType = Logger
 export default new Logger({ level: LOGGER_LEVEL })


### PR DESCRIPTION
### Description

Introduces a type-safe navigation API that allows apps using the framework to navigate to common screens (Send, Receive, Swap, etc.) and custom screens.

### Design approach

- Created a public `navigate` function that maps public route names to internal screens
- Leverages TypeScript's declaration merging to allow apps to extend the navigation types
- Maintains an abstraction layer between public and internal navigation to preserve flexibility
- Provides common screen navigation out of the box (Send, Receive, Swap, Add funds, etc.)
- Supports custom screens through type extension

## Example usage
```typescript
import {
  navigate,
  type StackParamList,
} from '@divvi/mobile'

// Navigate to built-in screens
navigate('Send')
navigate('Swap', { fromTokenId: 'celo-mainnet:native' })

// Navigate to custom screens (after extending types)
navigate('CustomScreen', { someParam: 'test' })

// Type-safe parameters
type RootStackParamList = StackParamList & {
  CustomScreen: {
    someParam: string
  }
}

declare global {
  namespace DivviNavigation {
    interface RootParamList extends RootStackParamList {}
  }
}
```

### Alternative considered

Direct exposure of React Navigation APIs

Pros:
- Direct usage of React Navigation's APIs
- No extra mapping layer to maintain
- Maybe more flexible for power users

Cons:
- Exposes internal implementation details (e.g. `Receive` screen being the `QRCode` screen in the `QRNavigator`)
- Harder to change navigation structure without breaking changes
- More complex API surface for basic use cases

The chosen approach provides a better balance between usability and maintainability, while still allowing for custom screen navigation when needed.

### Test plan

- Added tests
- Updated playground screen in the example app

https://github.com/user-attachments/assets/5ed171e3-6ae3-4b2c-97f7-cac73eee959f

### Related issues

- Fixes RET-1310

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
