### PR TITLE
fix: TS typecheck not working in the example app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,12 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+  apps-example:
+    name: apps/example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/yarn-install
+      - name: Typecheck
+        run: yarn typecheck
+        working-directory: apps/example

--- a/apps/example/e2e/tsconfig.json
+++ b/apps/example/e2e/tsconfig.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "../../../node_modules/expo/tsconfig.base.json",
-    "../../../node_modules/@divvi/mobile/tsconfig.json"
-  ]
-}

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -7,6 +7,7 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
+    "typecheck": "tsc --noEmit",
     "e2e:prebuild": "EXPO_PUBLIC_DIVVI_E2E=true expo prebuild --clean",
     "e2e:packager": "EXPO_PUBLIC_DIVVI_E2E=true yarn expo start",
     "e2e:build:android-debug": "EXPO_PUBLIC_DIVVI_E2E=true detox build -c android.debug",

--- a/apps/example/screens/PlaygroundScreen.tsx
+++ b/apps/example/screens/PlaygroundScreen.tsx
@@ -159,13 +159,13 @@ export default function PlaygroundScreen(_props: RootStackScreenProps<'Playgroun
             <View style={styles.feeRow}>
               <Text style={styles.feeLabel}>Estimated Fee:</Text>
               <Text style={styles.feeAmount}>
-                {fees.estimatedFeeAmount?.toString()} {fees.feeCurrency.symbol}
+                {fees.estimatedFeeAmount?.toString()} {fees.feeCurrency?.symbol}
               </Text>
             </View>
             <View style={styles.feeRow}>
               <Text style={styles.feeLabel}>Max Fee:</Text>
               <Text style={styles.feeAmount}>
-                {fees.maxFeeAmount?.toString()} {fees.feeCurrency.symbol}
+                {fees.maxFeeAmount?.toString()} {fees.feeCurrency?.symbol}
               </Text>
             </View>
           </View>

--- a/apps/example/tsconfig.json
+++ b/apps/example/tsconfig.json
@@ -1,8 +1,6 @@
 {
   // Temporary hack until we figure out a way for this to be { "extends": "expo/tsconfig.base" }
-  "extends": ["expo/tsconfig.base", "@divvi/mobile"],
-  "compilerOptions": {
-    "jsx": "react-native"
-  },
-  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
+  "extends": "@divvi/mobile",
+  // TODO: we should be able to remove the need to include the mobile package index.d.ts once we're able to ship declaration files
+  "include": ["**/*", "../../packages/@divvi/mobile/src/index.d.ts"],
 }

--- a/packages/@divvi/mobile/src/navigator/Navigator.tsx
+++ b/packages/@divvi/mobile/src/navigator/Navigator.tsx
@@ -101,6 +101,7 @@ import PincodeEnter from 'src/pincode/PincodeEnter'
 import PincodeSet from 'src/pincode/PincodeSet'
 import PointsHome from 'src/points/PointsHome'
 import PointsIntro from 'src/points/PointsIntro'
+import { NavigatorScreen } from 'src/public/navigate'
 import { RootState } from 'src/redux/reducers'
 import { store } from 'src/redux/store'
 import SendConfirmation, { sendConfirmationScreenNavOptions } from 'src/send/SendConfirmation'
@@ -134,8 +135,6 @@ const TAG = 'Navigator'
 const Stack = createNativeStackNavigator<StackParamList>()
 const ModalStack = createNativeStackNavigator<StackParamList>()
 const RootStack = createBottomSheetNavigator<StackParamList>()
-
-export type NavigatorScreen = typeof Stack.Screen
 
 const commonScreens = (Navigator: typeof Stack) => {
   return (
@@ -607,7 +606,7 @@ const pointsScreens = (Navigator: typeof Stack) => (
 )
 
 const customScreens = (Navigator: typeof Stack) => {
-  return getAppConfig().screens?.custom?.(Navigator.Screen) ?? null
+  return getAppConfig().screens?.custom?.(Navigator.Screen as NavigatorScreen) ?? null
 }
 
 const mapStateToProps = (state: RootState) => {

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -1,5 +1,5 @@
 import type { ImageSourcePropType } from 'react-native'
-import type { NavigatorScreen } from '../navigator/Navigator'
+import type { NavigatorScreen } from './navigate'
 
 // Type for tab configuration
 export interface TabScreenConfig {


### PR DESCRIPTION
### Description

TS typecheck was working but actually failing because it only included the `src` folder which is not present in the example.

I banged my head a little trying to make it all work (so things work slightly differently when typechecking in the context of the library vs the example app).

The main problem is we don't currently ship the types with the mobile library, requiring some specific setup in `tsconfig.json` of the final app.

I tried emitting the declarations but it gave too many errors (1400+), mostly similar to:

```
Exported variable 'defaultCountryCodeSelector' has or is using name 'State' from external module "/Users/jean/src/github.com/divvixyz/divvi-mobile/packages/@divvi/mobile/src/account/reducer" but cannot be named.
```

I think we'll be able to solve this once the wallet is consuming the library and we can make bigger changes in this repo (relative imports, require cycles, etc).

In the meantime, the current changes are much more limited in scope and allow TS checks to pass properly.
I've also added a CI check so we don't break them.

