### PR TITLE
chore: expose tsconfig.base.json

### DIFF
--- a/apps/example/tsconfig.json
+++ b/apps/example/tsconfig.json
@@ -1,6 +1,5 @@
 {
-  // Temporary hack until we figure out a way for this to be { "extends": "expo/tsconfig.base" }
-  "extends": "@divvi/mobile",
+  "extends": "@divvi/mobile/tsconfig.base",
   // TODO: we should be able to remove the need to include the mobile package index.d.ts once we're able to ship declaration files
   "include": ["**/*", "../../packages/@divvi/mobile/src/index.d.ts"]
 }

--- a/packages/@divvi/mobile/package.json
+++ b/packages/@divvi/mobile/package.json
@@ -21,6 +21,8 @@
     "node": ">=20"
   },
   "files": [
+    "tsconfig.json",
+    "tsconfig.base.json",
     "src",
     "locales",
     "plugin/build",

--- a/packages/@divvi/mobile/tsconfig.base.json
+++ b/packages/@divvi/mobile/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  // This tsconfig is intended to be used by apps consuming the divvi mobile package
+  // TODO: extend from "expo/tsconfig.base" once we're able to get rid of `src` absolute paths
+  "extends": "./tsconfig.json"
+}


### PR DESCRIPTION
### Description

Expose `tsconfig.base.json` for consuming apps

Once we're able to remove the `src` absolute imports, we can transparently update final applications without breaking them, they'll just use the update config.
And we keep the mobile package `tsconfig.json` just for internal use.