### PR TITLE
fix(icon): change default color for hidden eye icon

### DIFF
--- a/packages/@divvi/mobile/src/icons/HiddenEyeIcon.tsx
+++ b/packages/@divvi/mobile/src/icons/HiddenEyeIcon.tsx
@@ -7,7 +7,7 @@ export interface Props {
   color?: ColorValue
 }
 
-function HiddenEyeIcon({ color = Colors.accent, size = 24 }: Props) {
+function HiddenEyeIcon({ color = Colors.contentPrimary, size = 24 }: Props) {
   return (
     <Svg height={size} width={size} viewBox="0 0 24 24" fill="none" testID="HiddenEyeIcon">
       <G fill={color} stroke={color} clipPath="url(#a)">


### PR DESCRIPTION
### Description

So its consistent with the eye icon. Currently when hiding balance, the icon color flips between contentPrimary and accent

### Test plan

Manually

### Related issues

N/A

