### PR TITLE
test(e2e): scroll within token bottom sheet to select CELO

### DIFF
--- a/apps/example/e2e/src/usecases/OnRamps.js
+++ b/apps/example/e2e/src/usecases/OnRamps.js
@@ -35,6 +35,10 @@ export default onRamps = () => {
   `('Should display $token provider(s) for $$amount', async ({ token, amount }) => {
     // We use multiTap as sometimes the network select renders above the bottom sheet
     // This appears to be a detox specific issue as it is not reproducible in a non detox build
+    await waitFor(element(by.id(`${token}Symbol`)))
+      .toBeVisible()
+      .whileElement(by.id('TokenBottomSheet/FlatList'))
+      .scroll(100, 'down')
     await multiTap(`${token}Symbol`)
     await waitForElementById('FiatExchangeInput')
     await element(by.id('FiatExchangeInput')).replaceText(`${amount}`)

--- a/packages/@divvi/mobile/src/components/TokenBottomSheet.tsx
+++ b/packages/@divvi/mobile/src/components/TokenBottomSheet.tsx
@@ -269,6 +269,7 @@ function TokenBottomSheet({
         ref={tokenListRef}
         data={tokenList}
         keyExtractor={(item) => item.tokenId}
+        testID="TokenBottomSheet/FlatList"
         contentContainerStyle={{
           paddingBottom: insets.bottom,
           backgroundColor: Colors.backgroundPrimary,


### PR DESCRIPTION
### Description

When merged, https://github.com/valora-inc/address-metadata/pull/648 caused CELO to appear below the fold of the token bottom sheet, resulting in failing CI: [mainnet](https://github.com/divvi-xyz/divvi-mobile/actions/runs/15643503999).

### Test plan

- [x] Tested locally
- [x] Tested in CI

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A