### PR TITLE
fix: disable allowBackup on Android

### DIFF
--- a/apps/example/app.json
+++ b/apps/example/app.json
@@ -25,8 +25,7 @@
       }
     },
     "android": {
-      // disabled to prevent user's app data to be automatically backed up to their Google Drive
-      // See: https://stackoverflow.com/questions/55665337
+      // IMPORTANT: to avoid react-native-keychain issues when reinstalling the app
       "allowBackup": false,
       "edgeToEdgeEnabled": false,
       "adaptiveIcon": {


### PR DESCRIPTION
### Description

Disables [`allowBackup`](https://docs.expo.dev/versions/latest/config/app/#allowbackup) on Android.

### Test plan

- [x] Tested locally on Android
- [x] Tested in CI

### Related issues

- Part of ENG-636

### Backwards compatibility

Yes

### Network scalability

N/A
