### PR TITLE
fix: set @anolilab/multi-semantic-release version to 3.0.0-alpha.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@actions/github": "^5.1.1",
-    "@anolilab/multi-semantic-release": "^3.0.0.alpha.3",
+    "@anolilab/multi-semantic-release": "^3.0.0-alpha.3",
     "@jambit/eslint-plugin-typed-redux-saga": "^0.4.0",
     "@types/shelljs": "^0.8.11",
     "@types/yargs": "^17.0.32",

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@anolilab/multi-semantic-release@^3.0.0.alpha.3":
+"@anolilab/multi-semantic-release@^3.0.0-alpha.3":
   version "3.0.0-alpha.3"
   resolved "https://registry.yarnpkg.com/@anolilab/multi-semantic-release/-/multi-semantic-release-3.0.0-alpha.3.tgz#f9280972dac92387318d1240ec695e21350ef746"
   integrity sha512-7NygV04ubmxqxg7/jaLLBPQPOQEx8KC8718GH6jyywfv6dmEsZ+7VlG8C9n/81bWkNf7i0ClLCQwHWxonMiDpw==


### PR DESCRIPTION
### Description

Change `@anolilab/multi-semantic-release` version to `3.0.0-alpha.3` from `3.0.0.alpha.3`.

CI failing: [action](https://github.com/divvi-xyz/divvi-mobile/actions/runs/18956539554/job/54134652172).

```
npm error Invalid tag name "^3.0.0.alpha.3" of package "@anolilab/multi-semantic-release@^3.0.0.alpha.3": Tags may not have any characters that encodeURIComponent encodes.
```

### Test plan

N/A

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
