### PR TITLE
fix: enable edge to edge and set status bar to transparent

### DIFF
--- a/apps/example/app.json
+++ b/apps/example/app.json
@@ -51,15 +51,6 @@
         }
       ],
       [
-        "react-native-edge-to-edge",
-        {
-          "android": {
-            "parentTheme": "Default",
-            "enforceNavigationBarContrast": false
-          }
-        }
-      ],
-      [
         "expo-build-properties",
         {
           "android": {

--- a/packages/@divvi/mobile/package.json
+++ b/packages/@divvi/mobile/package.json
@@ -165,7 +165,6 @@
     "react-async-hook": "^4.0.0",
     "react-i18next": "^15.4.1",
     "react-native-android-open-settings": "^1.3.0",
-    "react-native-edge-to-edge": "1.6.0",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-picker-select": "^9.3.1",
     "react-native-platform-touchable": "^1.1.1",


### PR DESCRIPTION
### Description

Sets the status bar to transparent and prevents it from displaying the background color during modal opens and on the splash screen. Users who change their status bar type on Android with the app open may see extra padding at the bottom of screens until the app is closed and reopened; this seems fine, as the user is unlikely to toggle back and forth between status bar types, and the issue is resolved when the app is closed and reopened. 


### Test plan

- [x] Tested on iOS
- [x] Tested on Android
- [x] Tested in CI

### Android Before / After

| Android Before | Android After | 
| ----- | ----- |
| ![](https://github.com/user-attachments/assets/b0d04423-37f6-4566-91bb-c0a6efee9eb7) | ![](https://github.com/user-attachments/assets/1c776be7-6fb4-416b-8ed4-5f3b30ed641c) |
| ![](https://github.com/user-attachments/assets/b3847da9-1faa-4f47-aebd-2345374ddf19) | ![](https://github.com/user-attachments/assets/6795aada-b87a-4d56-ac14-f6804ed9b4dd) |
| ![](https://github.com/user-attachments/assets/1195d271-7769-4077-9465-ebace48d8442) | ![](https://github.com/user-attachments/assets/ec34e766-2ebe-403a-9f71-45027c6b1692) |
| ![](https://github.com/user-attachments/assets/7b86eaca-2c84-401a-81c9-1634f951ee21) | ![](https://github.com/user-attachments/assets/4b3d2853-bfeb-49fe-bb88-dfd2b2e2d55d) |

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
