### PR TITLE
ci: use android level 30 for e2e tests on main

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -32,8 +32,8 @@ jobs:
         # 24 is failing due to Let's Encrypt root certificate expiration
         # 25 is failing (RET-1274)
         # 26 is failing (RET-1275)
-        # 27, 28 is failing
-        android-api-level: [29]
+        # 27, 28, 29 are failing
+        android-api-level: [30]
     uses: ./.github/workflows/e2e-android.yml
     with:
       android-api-level: ${{ matrix.android-api-level }}


### PR DESCRIPTION
### Description

E2E tests on main have been failing consistently for some time: [action history](https://github.com/divvi-xyz/divvi-mobile/actions/workflows/e2e-main.yml).

The core issue is that the Android 27 emulator frequently fails during setup, sometimes with the "emulator" package must be installed error, and other times by simply timing out. These failures prevent the tests from running, making them unreliable indicators of when regressions are introduced.

As a temporary stopgap, this PR updates the test environment to use Android API 30 instead of 27. While not our ideal lowest-supported version, this restores meaningful test history and canary signal on main. A stable but imperfect canary is currently more valuable than a failing one.

We can revisit lowering the Android version in the future.