### PR TITLE
chore(release): remove alpha channel

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -7,7 +7,6 @@ module.exports = {
     {
       name: 'main',
       prerelease: 'alpha',
-      channel: 'alpha',
     },
   ],
   preset: 'conventionalcommits',


### PR DESCRIPTION
### Description

Remove `alpha` channel for releases, since we don't have any stable versions yet, but publishing to `alpha` prevents NPM from automatically updating the _latest_ version on the package page.

<img width="423" height="107" alt="image" src="https://github.com/user-attachments/assets/44caca03-c587-4749-84c7-ae2e44ecf47d" />


### Test plan

CI

### Related issues

NA

### Backwards compatibility

NA

### Network scalability

NA