### PR TITLE
chore(e2e): unblock E2E

### DIFF
--- a/apps/example/e2e/src/utils/dappList.js
+++ b/apps/example/e2e/src/utils/dappList.js
@@ -30,7 +30,7 @@ export async function fetchDappList(userAgent = '') {
   let dappList = null
   try {
     const response = await fetch(
-      'https://us-central1-celo-mobile-alfajores.cloudfunctions.net/dappList',
+      'https://us-central1-celo-mobile-mainnet.cloudfunctions.net/dappList',
       {
         headers: {
           'User-Agent': userAgent,


### PR DESCRIPTION
### Description

Unblock E2E Dapp List test. It is [currently failing](https://github.com/valora-xyz/wallet-stack/actions/runs/21408342753?pr=329) due to Alfajores endpoints unavailability.

### Test plan

CI

### Related issues

NA

### Backwards compatibility

Y

### Network scalability

NA