### PR TITLE
fix(ci): update Crowdin automerge for valora-bot

### DIFF
--- a/.github/scripts/automergeCrowdinPr.js
+++ b/.github/scripts/automergeCrowdinPr.js
@@ -10,7 +10,7 @@
  */
 
 const CROWDIN_BRANCH = 'l10n/main'
-const CROWDIN_PR_USER = 'divvi-bot-crowdin'
+const CROWDIN_PR_USER = 'valora-bot'
 
 const ALLOWED_UPDATED_FILE_MATCHER = new RegExp(
   `packages/wallet-stack/locales/.*/translation\\.json`


### PR DESCRIPTION
### Description

Update the automerge script to match PRs from the new bot account. Crowdin native integration now uses `valora-bot` instead of `divvi-bot-crowdin`.

### Test plan

CI