### PR TITLE
feat(send): minipay filter chip

### DIFF
--- a/packages/wallet-stack/src/analytics/Properties.tsx
+++ b/packages/wallet-stack/src/analytics/Properties.tsx
@@ -493,6 +493,7 @@ interface SendEventsProperties {
     amountEnteredIn: AmountEnteredIn
     tokenId: string | null
     networkId: string | null
+    isMiniPayRecipient: boolean
   }
   [SendEvents.send_confirm_back]: undefined
   [SendEvents.send_confirm_send]:

--- a/packages/wallet-stack/src/navigator/types.tsx
+++ b/packages/wallet-stack/src/navigator/types.tsx
@@ -42,6 +42,7 @@ type SendEnterAmountParams = {
   origin: SendOrigin
   forceTokenId?: boolean
   defaultTokenIdOverride?: string
+  isMiniPayRecipient?: boolean
 }
 
 interface ValidateRecipientParams {

--- a/packages/wallet-stack/src/send/EnterAmount.tsx
+++ b/packages/wallet-stack/src/send/EnterAmount.tsx
@@ -10,6 +10,7 @@ import BackButton from 'src/components/BackButton'
 import { BottomSheetModalRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes } from 'src/components/Button'
 import FeeInfoBottomSheet from 'src/components/FeeInfoBottomSheet'
+import { FilterChip } from 'src/components/FilterChipsCarousel'
 import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import { ReviewDetailsItem } from 'src/components/ReviewTransaction'
@@ -17,7 +18,6 @@ import TokenBottomSheet, {
   TokenBottomSheetProps,
   TokenPickerOrigin,
 } from 'src/components/TokenBottomSheet'
-import { FilterChip } from 'src/components/FilterChipsCarousel'
 import TokenEnterAmount, {
   FETCH_UPDATED_TRANSACTIONS_DEBOUNCE_TIME_MS,
   useEnterAmount,

--- a/packages/wallet-stack/src/send/EnterAmount.tsx
+++ b/packages/wallet-stack/src/send/EnterAmount.tsx
@@ -17,6 +17,7 @@ import TokenBottomSheet, {
   TokenBottomSheetProps,
   TokenPickerOrigin,
 } from 'src/components/TokenBottomSheet'
+import { FilterChip } from 'src/components/FilterChipsCarousel'
 import TokenEnterAmount, {
   FETCH_UPDATED_TRANSACTIONS_DEBOUNCE_TIME_MS,
   useEnterAmount,
@@ -66,6 +67,7 @@ interface Props {
   children?: React.ReactNode
   ProceedComponent: ComponentType<ProceedComponentProps>
   disableBalanceCheck?: boolean
+  filterChips?: FilterChip<TokenBalance>[]
 }
 
 export const SendProceed = ({
@@ -107,6 +109,7 @@ export default function EnterAmount({
   children,
   ProceedComponent,
   disableBalanceCheck = false,
+  filterChips,
 }: Props) {
   const { t } = useTranslation()
   const insets = useSafeAreaInsets()
@@ -325,6 +328,7 @@ export default function EnterAmount({
         tokens={tokens}
         title={t('sendEnterAmountScreen.selectToken')}
         titleStyle={styles.title}
+        filterChips={filterChips}
       />
     </SafeAreaView>
   )

--- a/packages/wallet-stack/src/send/SendEnterAmount.test.tsx
+++ b/packages/wallet-stack/src/send/SendEnterAmount.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import { fireEvent, render, waitFor, within } from '@testing-library/react-native'
 import BigNumber from 'bignumber.js'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -237,5 +237,75 @@ describe('SendEnterAmount', () => {
 
     expect(getByTestId('SendEnterAmount/TokenSelect')).toHaveTextContent('cUSD', { exact: false })
     expect(getByTestId('SendEnterAmount/TokenSelect')).toBeDisabled()
+  })
+
+  describe('MiniPay filter', () => {
+    const miniPayTokenIds = [mockCusdTokenId, mockCeurTokenId]
+
+    beforeEach(() => {
+      jest.mocked(getDynamicConfigParams).mockReturnValue({
+        miniPayTokenIds,
+      })
+    })
+
+    it('should show MiniPay chip pre-selected and only MiniPay tokens when isMiniPayRecipient is true', () => {
+      const { getAllByTestId, getByText } = render(
+        <Provider store={store}>
+          <MockedNavigator
+            component={SendEnterAmount}
+            params={{ ...params, isMiniPayRecipient: true }}
+          />
+        </Provider>
+      )
+
+      expect(getByText('MiniPay')).toBeTruthy()
+
+      const tokenBottomSheet = getAllByTestId('TokenBottomSheet')[0]
+      const tokens = within(tokenBottomSheet).getAllByTestId('TokenBalanceItem')
+      expect(tokens).toHaveLength(2)
+      expect(tokens[0]).toHaveTextContent('cEUR', { exact: false })
+      expect(tokens[1]).toHaveTextContent('cUSD', { exact: false })
+    })
+
+    it('should select default token from MiniPay list', () => {
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <MockedNavigator
+            component={SendEnterAmount}
+            params={{ ...params, isMiniPayRecipient: true }}
+          />
+        </Provider>
+      )
+
+      // cEUR has highest balance (100) among MiniPay tokens, not CELO (which is excluded)
+      expect(getByTestId('SendEnterAmount/TokenSelect')).toHaveTextContent('cEUR', { exact: false })
+    })
+
+    it('should show all tokens when MiniPay chip is toggled off', () => {
+      const { getAllByTestId, getByText } = render(
+        <Provider store={store}>
+          <MockedNavigator
+            component={SendEnterAmount}
+            params={{ ...params, isMiniPayRecipient: true }}
+          />
+        </Provider>
+      )
+
+      fireEvent.press(getByText('MiniPay'))
+
+      const tokenBottomSheet = getAllByTestId('TokenBottomSheet')[0]
+      const tokens = within(tokenBottomSheet).getAllByTestId('TokenBalanceItem')
+      expect(tokens).toHaveLength(3)
+    })
+
+    it('should not show MiniPay chip when isMiniPayRecipient is not set', () => {
+      const { queryByText } = render(
+        <Provider store={store}>
+          <MockedNavigator component={SendEnterAmount} params={params} />
+        </Provider>
+      )
+
+      expect(queryByText('MiniPay')).toBeFalsy()
+    })
   })
 })

--- a/packages/wallet-stack/src/send/SendEnterAmount.test.tsx
+++ b/packages/wallet-stack/src/send/SendEnterAmount.test.tsx
@@ -240,7 +240,7 @@ describe('SendEnterAmount', () => {
   })
 
   describe('MiniPay filter', () => {
-    const miniPayTokenIds = [mockCusdTokenId, mockCeurTokenId]
+    const miniPayTokenIds = [mockCusdTokenId, mockUSDCTokenId]
 
     beforeEach(() => {
       jest.mocked(getDynamicConfigParams).mockReturnValue({
@@ -262,9 +262,9 @@ describe('SendEnterAmount', () => {
 
       const tokenBottomSheet = getAllByTestId('TokenBottomSheet')[0]
       const tokens = within(tokenBottomSheet).getAllByTestId('TokenBalanceItem')
-      expect(tokens).toHaveLength(2)
-      expect(tokens[0]).toHaveTextContent('cEUR', { exact: false })
-      expect(tokens[1]).toHaveTextContent('cUSD', { exact: false })
+      // only cUSD visible (USDC is on a different network and filtered by selector)
+      expect(tokens).toHaveLength(1)
+      expect(tokens[0]).toHaveTextContent('cUSD', { exact: false })
     })
 
     it('should select default token from MiniPay list', () => {
@@ -277,8 +277,8 @@ describe('SendEnterAmount', () => {
         </Provider>
       )
 
-      // cEUR has highest balance (100) among MiniPay tokens, not CELO (which is excluded)
-      expect(getByTestId('SendEnterAmount/TokenSelect')).toHaveTextContent('cEUR', { exact: false })
+      // cUSD is the only MiniPay token with balance, not CELO (which is excluded)
+      expect(getByTestId('SendEnterAmount/TokenSelect')).toHaveTextContent('cUSD', { exact: false })
     })
 
     it('should show all tokens when MiniPay chip is toggled off', () => {
@@ -306,6 +306,37 @@ describe('SendEnterAmount', () => {
       )
 
       expect(queryByText('MiniPay')).toBeFalsy()
+    })
+
+    it('should include isMiniPayRecipient in send_amount_continue analytics', async () => {
+      jest.mocked(usePrepareSendTransactions).mockReturnValue({
+        prepareTransactionsResult: mockPrepareTransactionsResultPossible,
+        prepareTransactionLoading: false,
+        refreshPreparedTransactions: jest.fn(),
+        clearPreparedTransactions: jest.fn(),
+        prepareTransactionError: undefined,
+      })
+      const { getByTestId, getByText } = render(
+        <Provider store={store}>
+          <MockedNavigator
+            component={SendEnterAmount}
+            params={{ ...params, isMiniPayRecipient: true }}
+          />
+        </Provider>
+      )
+
+      fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '8')
+
+      await waitFor(() => expect(getByText('review')).not.toBeDisabled())
+      fireEvent.press(getByText('review'))
+
+      await waitFor(() => expect(AppAnalytics.track).toHaveBeenCalledTimes(1))
+      expect(AppAnalytics.track).toHaveBeenCalledWith(
+        SendEvents.send_amount_continue,
+        expect.objectContaining({
+          isMiniPayRecipient: true,
+        })
+      )
     })
   })
 })

--- a/packages/wallet-stack/src/send/SendEnterAmount.test.tsx
+++ b/packages/wallet-stack/src/send/SendEnterAmount.test.tsx
@@ -10,6 +10,7 @@ import { Screens } from 'src/navigator/Screens'
 import { RecipientType } from 'src/recipients/recipient'
 import SendEnterAmount from 'src/send/SendEnterAmount'
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
+import { getDynamicConfigParams } from 'src/statsig'
 import { getSerializablePreparedTransactionsPossible } from 'src/viem/preparedTransactionSerialization'
 import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
 import MockedNavigator from 'test/MockedNavigator'
@@ -28,6 +29,10 @@ import {
 
 jest.mock('src/statsig')
 jest.mock('src/send/usePrepareSendTransactions')
+
+jest.mocked(getDynamicConfigParams).mockReturnValue({
+  miniPayTokenIds: [],
+})
 
 const mockPrepareTransactionsResultPossible: PreparedTransactionsPossible = {
   type: 'possible',
@@ -164,6 +169,7 @@ describe('SendEnterAmount', () => {
       underlyingTokenAddress: mockCeloAddress,
       underlyingTokenSymbol: 'CELO',
       amountEnteredIn: 'token',
+      isMiniPayRecipient: false,
     })
     expect(navigate).toHaveBeenCalledWith(Screens.SendConfirmation, {
       origin: params.origin,

--- a/packages/wallet-stack/src/send/SendEnterAmount.tsx
+++ b/packages/wallet-stack/src/send/SendEnterAmount.tsx
@@ -23,8 +23,14 @@ type Props = NativeStackScreenProps<StackParamList, Screens.SendEnterAmount>
 const TAG = 'SendEnterAmount'
 
 function SendEnterAmount({ route }: Props) {
-  const { defaultTokenIdOverride, origin, recipient, isFromScan, forceTokenId, isMiniPayRecipient } =
-    route.params
+  const {
+    defaultTokenIdOverride,
+    origin,
+    recipient,
+    isFromScan,
+    forceTokenId,
+    isMiniPayRecipient,
+  } = route.params
   // explicitly allow zero state tokens to be shown for exploration purposes for
   // new users with no balance
   const tokens = useSelector(sortedTokensWithBalanceOrShowZeroBalanceSelector)

--- a/packages/wallet-stack/src/send/SendEnterAmount.tsx
+++ b/packages/wallet-stack/src/send/SendEnterAmount.tsx
@@ -11,6 +11,7 @@ import { useSelector } from 'src/redux/hooks'
 import EnterAmount, { ProceedArgs, SendProceed } from 'src/send/EnterAmount'
 import { lastUsedTokenIdSelector } from 'src/send/selectors'
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
+import useSendFilterChips from 'src/send/useSendFilterChips'
 import { sortedTokensWithBalanceOrShowZeroBalanceSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
@@ -22,18 +23,23 @@ type Props = NativeStackScreenProps<StackParamList, Screens.SendEnterAmount>
 const TAG = 'SendEnterAmount'
 
 function SendEnterAmount({ route }: Props) {
-  const { defaultTokenIdOverride, origin, recipient, isFromScan, forceTokenId } = route.params
+  const { defaultTokenIdOverride, origin, recipient, isFromScan, forceTokenId, isMiniPayRecipient } =
+    route.params
   // explicitly allow zero state tokens to be shown for exploration purposes for
   // new users with no balance
   const tokens = useSelector(sortedTokensWithBalanceOrShowZeroBalanceSelector)
   const lastUsedTokenId = useSelector(lastUsedTokenIdSelector)
+  const { filterChips, miniPayTokenIds } = useSendFilterChips(isMiniPayRecipient)
 
   const defaultToken = useMemo(() => {
-    const defaultToken = tokens.find((token) => token.tokenId === defaultTokenIdOverride)
-    const lastUsedToken = tokens.find((token) => token.tokenId === lastUsedTokenId)
+    const eligibleTokens = miniPayTokenIds
+      ? tokens.filter((token) => miniPayTokenIds.includes(token.tokenId))
+      : tokens
+    const defaultToken = eligibleTokens.find((token) => token.tokenId === defaultTokenIdOverride)
+    const lastUsedToken = eligibleTokens.find((token) => token.tokenId === lastUsedTokenId)
 
-    return defaultToken ?? lastUsedToken ?? tokens[0]
-  }, [tokens, defaultTokenIdOverride, lastUsedTokenId])
+    return defaultToken ?? lastUsedToken ?? eligibleTokens[0]
+  }, [tokens, miniPayTokenIds, defaultTokenIdOverride, lastUsedTokenId])
 
   const localCurrencyCode = useSelector(getLocalCurrencyCode)
   const localCurrencyExchangeRate = useSelector(usdToLocalCurrencyRateSelector)
@@ -72,6 +78,7 @@ function SendEnterAmount({ route }: Props) {
       amountEnteredIn,
       tokenId: token.tokenId,
       networkId: token.networkId,
+      isMiniPayRecipient: isMiniPayRecipient ?? false,
     })
   }
 
@@ -116,6 +123,7 @@ function SendEnterAmount({ route }: Props) {
       tokenSelectionDisabled={!!forceTokenId}
       onPressProceed={handleReviewSend}
       ProceedComponent={SendProceed}
+      filterChips={filterChips}
     />
   )
 }

--- a/packages/wallet-stack/src/send/SendEnterAmount.tsx
+++ b/packages/wallet-stack/src/send/SendEnterAmount.tsx
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import BigNumber from 'bignumber.js'
-import React, { useMemo } from 'react'
+import React from 'react'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { SendEvents } from 'src/analytics/Events'
 import { getLocalCurrencyCode, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
@@ -35,17 +35,12 @@ function SendEnterAmount({ route }: Props) {
   // new users with no balance
   const tokens = useSelector(sortedTokensWithBalanceOrShowZeroBalanceSelector)
   const lastUsedTokenId = useSelector(lastUsedTokenIdSelector)
-  const { filterChips, miniPayTokenIds } = useSendFilterChips(isMiniPayRecipient)
-
-  const defaultToken = useMemo(() => {
-    const eligibleTokens = miniPayTokenIds
-      ? tokens.filter((token) => miniPayTokenIds.includes(token.tokenId))
-      : tokens
-    const defaultToken = eligibleTokens.find((token) => token.tokenId === defaultTokenIdOverride)
-    const lastUsedToken = eligibleTokens.find((token) => token.tokenId === lastUsedTokenId)
-
-    return defaultToken ?? lastUsedToken ?? eligibleTokens[0]
-  }, [tokens, miniPayTokenIds, defaultTokenIdOverride, lastUsedTokenId])
+  const { filterChips, defaultToken } = useSendFilterChips({
+    isMiniPayRecipient,
+    tokens,
+    defaultTokenIdOverride,
+    lastUsedTokenId,
+  })
 
   const localCurrencyCode = useSelector(getLocalCurrencyCode)
   const localCurrencyExchangeRate = useSelector(usdToLocalCurrencyRateSelector)

--- a/packages/wallet-stack/src/send/useSendFilterChips.ts
+++ b/packages/wallet-stack/src/send/useSendFilterChips.ts
@@ -1,0 +1,29 @@
+import { BooleanFilterChip } from 'src/components/FilterChipsCarousel'
+import { getDynamicConfigParams } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs } from 'src/statsig/types'
+import { TokenBalance } from 'src/tokens/slice'
+
+export default function useSendFilterChips(isMiniPayRecipient?: boolean): {
+  filterChips: BooleanFilterChip<TokenBalance>[]
+  miniPayTokenIds: string[] | null
+} {
+  const { miniPayTokenIds: configTokenIds } = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.SEND_CONFIG]
+  )
+  const miniPayTokenIds =
+    isMiniPayRecipient && configTokenIds.length > 0 ? configTokenIds : null
+
+  const filterChips: BooleanFilterChip<TokenBalance>[] = miniPayTokenIds
+    ? [
+        {
+          id: 'minipay',
+          name: 'MiniPay',
+          filterFn: (token: TokenBalance) => miniPayTokenIds.includes(token.tokenId),
+          isSelected: true,
+        },
+      ]
+    : []
+
+  return { filterChips, miniPayTokenIds }
+}

--- a/packages/wallet-stack/src/send/useSendFilterChips.ts
+++ b/packages/wallet-stack/src/send/useSendFilterChips.ts
@@ -11,8 +11,7 @@ export default function useSendFilterChips(isMiniPayRecipient?: boolean): {
   const { miniPayTokenIds: configTokenIds } = getDynamicConfigParams(
     DynamicConfigs[StatsigDynamicConfigs.SEND_CONFIG]
   )
-  const miniPayTokenIds =
-    isMiniPayRecipient && configTokenIds.length > 0 ? configTokenIds : null
+  const miniPayTokenIds = isMiniPayRecipient && configTokenIds.length > 0 ? configTokenIds : null
 
   const filterChips: BooleanFilterChip<TokenBalance>[] = miniPayTokenIds
     ? [

--- a/packages/wallet-stack/src/send/useSendFilterChips.ts
+++ b/packages/wallet-stack/src/send/useSendFilterChips.ts
@@ -5,9 +5,19 @@ import { DynamicConfigs } from 'src/statsig/constants'
 import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { TokenBalance } from 'src/tokens/slice'
 
-export default function useSendFilterChips(isMiniPayRecipient?: boolean): {
+export default function useSendFilterChips({
+  isMiniPayRecipient,
+  tokens,
+  defaultTokenIdOverride,
+  lastUsedTokenId,
+}: {
+  isMiniPayRecipient?: boolean
+  tokens: TokenBalance[]
+  defaultTokenIdOverride?: string
+  lastUsedTokenId?: string | null
+}): {
   filterChips: BooleanFilterChip<TokenBalance>[]
-  miniPayTokenIds: string[] | null
+  defaultToken: TokenBalance | undefined
 } {
   const { miniPayTokenIds: configTokenIds } = getDynamicConfigParams(
     DynamicConfigs[StatsigDynamicConfigs.SEND_CONFIG]
@@ -29,5 +39,15 @@ export default function useSendFilterChips(isMiniPayRecipient?: boolean): {
     [miniPayTokenIds]
   )
 
-  return { filterChips, miniPayTokenIds }
+  const defaultToken = useMemo(() => {
+    const eligibleTokens = miniPayTokenIds
+      ? tokens.filter((token) => miniPayTokenIds.includes(token.tokenId))
+      : tokens
+    const defaultToken = eligibleTokens.find((token) => token.tokenId === defaultTokenIdOverride)
+    const lastUsedToken = eligibleTokens.find((token) => token.tokenId === lastUsedTokenId)
+
+    return defaultToken ?? lastUsedToken ?? eligibleTokens[0]
+  }, [tokens, miniPayTokenIds, defaultTokenIdOverride, lastUsedTokenId])
+
+  return { filterChips, defaultToken }
 }

--- a/packages/wallet-stack/src/send/useSendFilterChips.ts
+++ b/packages/wallet-stack/src/send/useSendFilterChips.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { BooleanFilterChip } from 'src/components/FilterChipsCarousel'
 import { getDynamicConfigParams } from 'src/statsig'
 import { DynamicConfigs } from 'src/statsig/constants'
@@ -13,16 +14,20 @@ export default function useSendFilterChips(isMiniPayRecipient?: boolean): {
   )
   const miniPayTokenIds = isMiniPayRecipient && configTokenIds.length > 0 ? configTokenIds : null
 
-  const filterChips: BooleanFilterChip<TokenBalance>[] = miniPayTokenIds
-    ? [
-        {
-          id: 'minipay',
-          name: 'MiniPay',
-          filterFn: (token: TokenBalance) => miniPayTokenIds.includes(token.tokenId),
-          isSelected: true,
-        },
-      ]
-    : []
+  const filterChips: BooleanFilterChip<TokenBalance>[] = useMemo(
+    () =>
+      miniPayTokenIds
+        ? [
+            {
+              id: 'minipay',
+              name: 'MiniPay',
+              filterFn: (token: TokenBalance) => miniPayTokenIds.includes(token.tokenId),
+              isSelected: true,
+            },
+          ]
+        : [],
+    [miniPayTokenIds]
+  )
 
   return { filterChips, miniPayTokenIds }
 }

--- a/packages/wallet-stack/src/send/useSendFilterChips.ts
+++ b/packages/wallet-stack/src/send/useSendFilterChips.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { BooleanFilterChip } from 'src/components/FilterChipsCarousel'
 import { getDynamicConfigParams } from 'src/statsig'
 import { DynamicConfigs } from 'src/statsig/constants'
@@ -24,30 +23,24 @@ export default function useSendFilterChips({
   )
   const miniPayTokenIds = isMiniPayRecipient && configTokenIds.length > 0 ? configTokenIds : null
 
-  const filterChips: BooleanFilterChip<TokenBalance>[] = useMemo(
-    () =>
-      miniPayTokenIds
-        ? [
-            {
-              id: 'minipay',
-              name: 'MiniPay',
-              filterFn: (token: TokenBalance) => miniPayTokenIds.includes(token.tokenId),
-              isSelected: true,
-            },
-          ]
-        : [],
-    [miniPayTokenIds]
-  )
+  const filterChips: BooleanFilterChip<TokenBalance>[] = miniPayTokenIds
+    ? [
+        {
+          id: 'minipay',
+          name: 'MiniPay',
+          filterFn: (token: TokenBalance) => miniPayTokenIds.includes(token.tokenId),
+          isSelected: true,
+        },
+      ]
+    : []
 
-  const defaultToken = useMemo(() => {
-    const eligibleTokens = miniPayTokenIds
-      ? tokens.filter((token) => miniPayTokenIds.includes(token.tokenId))
-      : tokens
-    const defaultToken = eligibleTokens.find((token) => token.tokenId === defaultTokenIdOverride)
-    const lastUsedToken = eligibleTokens.find((token) => token.tokenId === lastUsedTokenId)
-
-    return defaultToken ?? lastUsedToken ?? eligibleTokens[0]
-  }, [tokens, miniPayTokenIds, defaultTokenIdOverride, lastUsedTokenId])
+  const eligibleTokens = miniPayTokenIds
+    ? tokens.filter((token) => miniPayTokenIds.includes(token.tokenId))
+    : tokens
+  const defaultToken =
+    eligibleTokens.find((token) => token.tokenId === defaultTokenIdOverride) ??
+    eligibleTokens.find((token) => token.tokenId === lastUsedTokenId) ??
+    eligibleTokens[0]
 
   return { filterChips, defaultToken }
 }

--- a/packages/wallet-stack/src/statsig/constants.ts
+++ b/packages/wallet-stack/src/statsig/constants.ts
@@ -164,6 +164,12 @@ export const DynamicConfigs = {
       inviteRewardsVersion: 'none',
     },
   },
+  [StatsigDynamicConfigs.SEND_CONFIG]: {
+    configName: StatsigDynamicConfigs.SEND_CONFIG,
+    defaultValues: {
+      miniPayTokenIds: [] as string[],
+    },
+  },
 } satisfies {
   [key in StatsigDynamicConfigs]: {
     configName: key

--- a/packages/wallet-stack/src/statsig/types.ts
+++ b/packages/wallet-stack/src/statsig/types.ts
@@ -11,6 +11,7 @@ export enum StatsigDynamicConfigs {
   DEMO_MODE_CONFIG = 'demo_mode_config',
   FIAT_CONNECT_CONFIG = 'fiat_connect_config',
   INVITE_REWARDS_CONFIG = 'invite_rewards_config',
+  SEND_CONFIG = 'send_config',
 }
 
 export enum StatsigFeatureGates {


### PR DESCRIPTION
### Description

When sending tokens to a MiniPay recipient, the token picker shows a "MiniPay" filter chip (pre-selected by default) that limits visible tokens to a configured set. Users can toggle the chip off to see all tokens.

### Changes

- Added `SEND_CONFIG` [Statsig dynamic config](https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/dynamic_configs/send_config) with `miniPayTokenIds` list
- Added `isMiniPayRecipient` navigation param to `SendEnterAmount`
- Created `useSendFilterChips` hook (mirrors swap's `useFilterChips` pattern)
- Default token selection respects the MiniPay filter when active
- Added `isMiniPayRecipient` to `send_amount_continue` analytics event

https://github.com/user-attachments/assets/70413696-1c54-4258-86f7-8db17ef228ff  

### Test plan

- Updated unit test
- Tested manually (see overrides in https://github.com/valora-xyz/wallet-stack/commit/b8435ebd6b99972f432ffe24ee6d528473a89fb3)

### Related issues

- Related to  [#11708](https://github.com/celo-org/celo-monorepo/issues/11708)
- https://github.com/valora-xyz/wallet-stack/pull/369

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
