### PR TITLE
feat(send): handle phone number `verifiedBy`

### DIFF
--- a/packages/wallet-stack/src/identity/actions.ts
+++ b/packages/wallet-stack/src/identity/actions.ts
@@ -1,6 +1,7 @@
 import {
   AddressToDisplayNameType,
   AddressToE164NumberType,
+  AddressToVerifiedByType,
   AddressValidationType,
   E164NumberToAddressType,
 } from 'src/identity/reducer'
@@ -31,6 +32,7 @@ export interface UpdateE164PhoneNumberAddressesAction {
   type: Actions.UPDATE_E164_PHONE_NUMBER_ADDRESSES
   e164NumberToAddress: E164NumberToAddressType
   addressToE164Number: AddressToE164NumberType
+  addressToVerifiedBy: AddressToVerifiedByType
 }
 
 export interface UpdateKnownAddressesAction {
@@ -162,11 +164,13 @@ export const endFetchingAddresses = (
 
 export const updateE164PhoneNumberAddresses = (
   e164NumberToAddress: E164NumberToAddressType,
-  addressToE164Number: AddressToE164NumberType
+  addressToE164Number: AddressToE164NumberType,
+  addressToVerifiedBy: AddressToVerifiedByType = {}
 ): UpdateE164PhoneNumberAddressesAction => ({
   type: Actions.UPDATE_E164_PHONE_NUMBER_ADDRESSES,
   e164NumberToAddress,
   addressToE164Number,
+  addressToVerifiedBy,
 })
 
 export const updateKnownAddresses = (

--- a/packages/wallet-stack/src/identity/contactMapping.test.ts
+++ b/packages/wallet-stack/src/identity/contactMapping.test.ts
@@ -115,7 +115,8 @@ describe('Fetch Addresses Saga', () => {
         .put(
           updateE164PhoneNumberAddresses(
             { [mockE164Number]: ['0xabc'] },
-            { '0xabc': mockE164Number }
+            { '0xabc': mockE164Number },
+            {}
           )
         )
         .run()
@@ -151,7 +152,45 @@ describe('Fetch Addresses Saga', () => {
         .put(
           updateE164PhoneNumberAddresses(
             { [mockE164Number]: ['0xabc', '0xdef'] },
-            { '0xabc': mockE164Number, '0xdef': mockE164Number }
+            { '0xabc': mockE164Number, '0xdef': mockE164Number },
+            {}
+          )
+        )
+        .put(requireSecureSend(mockE164Number, AddressValidationType.PARTIAL))
+        .run()
+    })
+
+    it('uses verifiedAddresses as source of truth when present', async () => {
+      const mockE164NumberToAddress = {
+        [mockE164Number]: [mockAccount.toLowerCase()],
+      }
+      // addresses only contains DB-verified addresses (backward compat),
+      // verifiedAddresses contains all (DB + SC) and is the source of truth
+      mockFetch.mockResponseOnce(
+        JSON.stringify({
+          data: {
+            addresses: ['0xAbC'],
+            verifiedAddresses: [
+              { address: '0xAbC', verifiedBy: 'valora' },
+              { address: '0xDef', verifiedBy: 'minipay' },
+            ],
+          },
+        })
+      )
+
+      await expectSaga(fetchAddressesAndValidateSaga, fetchAddressesAndValidate(mockE164Number))
+        .provide([
+          [select(e164NumberToAddressSelector), mockE164NumberToAddress],
+          [select(walletAddressSelector), mockAccount],
+          [call(retrieveSignedMessage), 'some signed message'],
+          [select(secureSendPhoneNumberMappingSelector), {}],
+        ])
+        .put(updateE164PhoneNumberAddresses({ [mockE164Number]: undefined }, {}))
+        .put(
+          updateE164PhoneNumberAddresses(
+            { [mockE164Number]: ['0xabc', '0xdef'] },
+            { '0xabc': mockE164Number, '0xdef': mockE164Number },
+            { '0xabc': 'valora', '0xdef': 'minipay' }
           )
         )
         .put(requireSecureSend(mockE164Number, AddressValidationType.PARTIAL))

--- a/packages/wallet-stack/src/identity/contactMapping.ts
+++ b/packages/wallet-stack/src/identity/contactMapping.ts
@@ -159,10 +159,22 @@ export function* fetchAddressesAndValidateSaga({
     // Clear existing entries for those numbers so our mapping consumers know new status is pending.
     yield* put(updateE164PhoneNumberAddresses({ [e164Number]: undefined }, {}))
 
-    const walletAddresses: string[] = yield* call(fetchWalletAddresses, e164Number)
+    const { addresses, verifiedAddresses } = yield* call(fetchWalletAddresses, e164Number)
+
+    // When `verifiedAddresses` is present, use it as source of truth:
+    // it includes addresses verified by both CPV and SocialConnect.
+    // The `addresses` field is used for backward compatibility.
+    const walletAddresses = verifiedAddresses ? verifiedAddresses.map((v) => v.address) : addresses
 
     const e164NumberToAddressUpdates: E164NumberToAddressType = {}
     const addressToE164NumberUpdates: AddressToE164NumberType = {}
+    const addressToVerifiedByUpdates: Record<string, string> = {}
+
+    if (verifiedAddresses) {
+      for (const { address, verifiedBy } of verifiedAddresses) {
+        addressToVerifiedByUpdates[address] = verifiedBy
+      }
+    }
 
     if (!walletAddresses.length) {
       Logger.debug(TAG + '@fetchAddressesAndValidate', `No addresses for number`)
@@ -197,7 +209,11 @@ export function* fetchAddressesAndValidateSaga({
       yield* put(requireSecureSend(e164Number, addressValidationType))
     }
     yield* put(
-      updateE164PhoneNumberAddresses(e164NumberToAddressUpdates, addressToE164NumberUpdates)
+      updateE164PhoneNumberAddresses(
+        e164NumberToAddressUpdates,
+        addressToE164NumberUpdates,
+        addressToVerifiedByUpdates
+      )
     )
     yield* put(endFetchingAddresses(e164Number, true))
     AppAnalytics.track(IdentityEvents.phone_number_lookup_complete)
@@ -265,9 +281,22 @@ function* fetchWalletAddresses(e164Number: string) {
       throw new Error(`Failed to look up phone number: ${response.status} ${response.statusText}`)
     }
 
-    const { data }: { data: { addresses: string[] } } = yield* call([response, 'json'])
+    const {
+      data,
+    }: {
+      data: {
+        addresses: string[]
+        verifiedAddresses?: Array<{ address: string; verifiedBy: string }>
+      }
+    } = yield* call([response, 'json'])
 
-    return data.addresses.map((address) => address.toLowerCase())
+    return {
+      addresses: data.addresses.map((address) => address.toLowerCase()),
+      verifiedAddresses: data.verifiedAddresses?.map((v) => ({
+        ...v,
+        address: v.address.toLowerCase(),
+      })),
+    }
   } catch (error) {
     Logger.debug(`${TAG}/fetchWalletAddresses`, 'Unable to look up phone number', error)
     throw new Error('Unable to fetch wallet address for this phone number')

--- a/packages/wallet-stack/src/identity/reducer.ts
+++ b/packages/wallet-stack/src/identity/reducer.ts
@@ -54,6 +54,10 @@ export interface AddressToVerificationStatus {
   [address: string]: boolean | undefined
 }
 
+export interface AddressToVerifiedByType {
+  [address: string]: string | undefined
+}
+
 interface State {
   addressToE164Number: AddressToE164NumberType
   // Note: Do not access values in this directly, use the `getAddressFromPhoneNumber` helper in contactMapping
@@ -67,6 +71,8 @@ interface State {
   secureSendPhoneNumberMapping: SecureSendPhoneNumberMapping
   // Mapping of address to verification status; undefined entries represent a loading state
   addressToVerificationStatus: AddressToVerificationStatus
+  // Mapping of address to the entity that verified it (e.g. "valora", "minipay")
+  addressToVerifiedBy: AddressToVerifiedByType
   lastSavedContactsHash: string | null
   shouldRefreshStoredPasswordHash: boolean
 }
@@ -83,6 +89,7 @@ const initialState: State = {
   },
   secureSendPhoneNumberMapping: {},
   addressToVerificationStatus: {},
+  addressToVerifiedBy: {},
   lastSavedContactsHash: null,
   shouldRefreshStoredPasswordHash: false,
 }
@@ -113,6 +120,10 @@ export const reducer = (
         e164NumberToAddress: {
           ...state.e164NumberToAddress,
           ...action.e164NumberToAddress,
+        },
+        addressToVerifiedBy: {
+          ...state.addressToVerifiedBy,
+          ...action.addressToVerifiedBy,
         },
       }
     case Actions.UPDATE_KNOWN_ADDRESSES:

--- a/packages/wallet-stack/src/identity/selectors.ts
+++ b/packages/wallet-stack/src/identity/selectors.ts
@@ -4,6 +4,7 @@ export const e164NumberToAddressSelector = (state: RootState) => state.identity.
 export const addressToVerificationStatusSelector = (state: RootState) =>
   state.identity.addressToVerificationStatus
 export const addressToE164NumberSelector = (state: RootState) => state.identity.addressToE164Number
+export const addressToVerifiedBySelector = (state: RootState) => state.identity.addressToVerifiedBy
 export const secureSendPhoneNumberMappingSelector = (state: RootState) =>
   state.identity.secureSendPhoneNumberMapping
 export const importContactsProgressSelector = (state: RootState) =>

--- a/packages/wallet-stack/src/navigator/types.tsx
+++ b/packages/wallet-stack/src/navigator/types.tsx
@@ -42,6 +42,7 @@ type SendEnterAmountParams = {
   origin: SendOrigin
   forceTokenId?: boolean
   defaultTokenIdOverride?: string
+  isMiniPayRecipient?: boolean
 }
 
 interface ValidateRecipientParams {

--- a/packages/wallet-stack/src/recipients/RecipientItemV2.tsx
+++ b/packages/wallet-stack/src/recipients/RecipientItemV2.tsx
@@ -64,11 +64,7 @@ function RecipientItem({ recipient, onSelectRecipient, loading, selected }: Prop
           />
           {!!showAppIcon && (
             <View style={styles.appIcon} testID="RecipientItem/AppIcon">
-              <Checkmark
-                color={Colors.contentTertiary}
-                height={ICON_SIZE}
-                width={ICON_SIZE}
-              />
+              <Checkmark color={Colors.contentTertiary} height={ICON_SIZE} width={ICON_SIZE} />
             </View>
           )}
         </View>

--- a/packages/wallet-stack/src/recipients/RecipientItemV2.tsx
+++ b/packages/wallet-stack/src/recipients/RecipientItemV2.tsx
@@ -9,7 +9,7 @@ import {
   addressToVerificationStatusSelector,
   e164NumberToAddressSelector,
 } from 'src/identity/selectors'
-import Logo from 'src/images/Logo'
+import Checkmark from 'src/icons/Checkmark'
 import {
   Recipient,
   RecipientType,
@@ -63,12 +63,13 @@ function RecipientItem({ recipient, onSelectRecipient, loading, selected }: Prop
             DefaultIcon={() => renderDefaultIcon(recipient)} // no need to honor color props here since the color we need match the defaults
           />
           {!!showAppIcon && (
-            <Logo
-              color={Colors.contentSecondary}
-              style={styles.appIcon}
-              size={ICON_SIZE}
-              testID="RecipientItem/AppIcon"
-            />
+            <View style={styles.appIcon} testID="RecipientItem/AppIcon">
+              <Checkmark
+                color={Colors.contentTertiary}
+                height={ICON_SIZE}
+                width={ICON_SIZE}
+              />
+            </View>
           )}
         </View>
         <View style={styles.contentContainer}>
@@ -129,13 +130,8 @@ const styles = StyleSheet.create({
     top: 22,
     left: 22,
     backgroundColor: Colors.accent,
-    padding: 4,
     borderRadius: 100,
-    // To override the default shadow props on the logo
-    shadowColor: undefined,
-    shadowOpacity: undefined,
-    shadowRadius: undefined,
-    shadowOffset: undefined,
+    padding: 2,
   },
 })
 

--- a/packages/wallet-stack/src/redux/migrations.test.ts
+++ b/packages/wallet-stack/src/redux/migrations.test.ts
@@ -67,6 +67,7 @@ import {
   v235Schema,
   v251Schema,
   v253Schema,
+  v254Schema,
   v28Schema,
   v2Schema,
   v35Schema,
@@ -1936,5 +1937,13 @@ describe('Redux persist migrations', () => {
     const expectedSchema: any = _.cloneDeep(oldSchema)
     expectedSchema.home = _.omit(oldSchema.home, 'hasSeenDivviBottomSheet')
     expect(migratedSchema).toStrictEqual(expectedSchema)
+  })
+
+  it('works from 254 to 255', () => {
+    const oldSchema = {
+      ...v254Schema,
+    }
+    const migratedSchema = migrations[255](oldSchema)
+    expect(migratedSchema.identity.addressToVerifiedBy).toStrictEqual({})
   })
 })

--- a/packages/wallet-stack/src/redux/migrations.ts
+++ b/packages/wallet-stack/src/redux/migrations.ts
@@ -2070,4 +2070,11 @@ export const migrations = {
     ...state,
     home: _.omit(state.home, 'hasSeenDivviBottomSheet'),
   }),
+  255: (state: any) => ({
+    ...state,
+    identity: {
+      ...state.identity,
+      addressToVerifiedBy: {},
+    },
+  }),
 }

--- a/packages/wallet-stack/src/redux/store.test.ts
+++ b/packages/wallet-stack/src/redux/store.test.ts
@@ -143,7 +143,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 254,
+          "version": 255,
         },
         "account": {
           "acceptedTerms": false,
@@ -245,6 +245,7 @@ describe('store state', () => {
           "addressToDisplayName": {},
           "addressToE164Number": {},
           "addressToVerificationStatus": {},
+          "addressToVerifiedBy": {},
           "askedContactsPermission": false,
           "e164NumberToAddress": {},
           "importContactsProgress": {

--- a/packages/wallet-stack/src/redux/store.ts
+++ b/packages/wallet-stack/src/redux/store.ts
@@ -30,7 +30,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-xyz/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 254,
+  version: 255,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],

--- a/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
+++ b/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
@@ -243,6 +243,7 @@ describe('SendSelectRecipient', () => {
       forceTokenId: undefined,
       recipient: expect.any(Object),
       origin: SendOrigin.AppSendFlow,
+      isMiniPayRecipient: false,
     })
   })
   it('navigates to send amount when address recipient is pressed', async () => {
@@ -280,6 +281,7 @@ describe('SendSelectRecipient', () => {
       forceTokenId: undefined,
       recipient: expect.any(Object),
       origin: SendOrigin.AppSendFlow,
+      isMiniPayRecipient: false,
     })
   })
 
@@ -522,6 +524,54 @@ describe('SendSelectRecipient', () => {
         recipientType: 'PhoneNumber',
       },
       origin: SendOrigin.AppSendFlow,
+      isMiniPayRecipient: false,
+    })
+  })
+  it('navigates to send amount with isMiniPayRecipient when address is verified by minipay', async () => {
+    jest
+      .mocked(getRecipientVerificationStatus)
+      .mockReturnValue(RecipientVerificationStatus.VERIFIED)
+
+    const store = createMockStore({
+      ...storeWithPhoneVerified,
+      identity: {
+        secureSendPhoneNumberMapping: {
+          [mockE164Number3]: { addressValidationType: AddressValidationType.NONE },
+        },
+        e164NumberToAddress: { [mockE164Number3]: [mockAccount3] },
+        addressToVerifiedBy: { [mockAccount3]: 'minipay' },
+      },
+    })
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <SendSelectRecipient {...mockScreenProps({})} />
+      </Provider>
+    )
+    const searchInput = getByTestId('SendSelectRecipientSearchInput')
+
+    await act(() => {
+      fireEvent.changeText(searchInput, mockE164Number3)
+    })
+    await act(() => {
+      fireEvent.press(getByTestId('RecipientItem'))
+    })
+    await act(() => {
+      fireEvent.press(getByTestId('SendOrInviteButton'))
+    })
+
+    expect(navigate).toHaveBeenCalledWith(Screens.SendEnterAmount, {
+      isFromScan: false,
+      defaultTokenIdOverride: undefined,
+      forceTokenId: undefined,
+      recipient: {
+        address: mockAccount3,
+        displayNumber: '(415) 555-0123',
+        e164PhoneNumber: mockE164Number3,
+        recipientType: 'PhoneNumber',
+      },
+      origin: SendOrigin.AppSendFlow,
+      isMiniPayRecipient: true,
     })
   })
   it('navigates to secure send flow when phone number recipient with multiple addresses, first time seeing it', async () => {
@@ -631,6 +681,7 @@ describe('SendSelectRecipient', () => {
         recipientType: 'PhoneNumber',
       },
       origin: SendOrigin.AppSendFlow,
+      isMiniPayRecipient: false,
     })
   })
   it.each([{ searchAddress: mockAccount2 }, { searchAddress: mockAccount3 }])(
@@ -694,6 +745,7 @@ describe('SendSelectRecipient', () => {
           thumbnailPath: undefined,
         },
         origin: SendOrigin.AppSendFlow,
+        isMiniPayRecipient: false,
       })
     }
   )
@@ -759,6 +811,7 @@ describe('SendSelectRecipient', () => {
           thumbnailPath: undefined,
         },
         origin: SendOrigin.AppSendFlow,
+        isMiniPayRecipient: false,
       })
     }
   )

--- a/packages/wallet-stack/src/send/SendSelectRecipient.tsx
+++ b/packages/wallet-stack/src/send/SendSelectRecipient.tsx
@@ -21,6 +21,7 @@ import { getAddressFromPhoneNumber } from 'src/identity/contactMapping'
 import { AddressValidationType } from 'src/identity/reducer'
 import { getAddressValidationType } from 'src/identity/secureSend'
 import {
+  addressToVerifiedBySelector,
   e164NumberToAddressSelector,
   secureSendPhoneNumberMappingSelector,
 } from 'src/identity/selectors'
@@ -215,6 +216,7 @@ function SendSelectRecipient({ route }: Props) {
   const dispatch = useDispatch()
   const secureSendPhoneNumberMapping = useSelector(secureSendPhoneNumberMappingSelector)
   const e164NumberToAddress = useSelector(e164NumberToAddressSelector)
+  const addressToVerifiedBy = useSelector(addressToVerifiedBySelector)
   const shareUrl = getAppConfig().experimental?.inviteFriends?.shareUrl ?? null
 
   const forceTokenId = route.params?.forceTokenId
@@ -314,6 +316,7 @@ function SendSelectRecipient({ route }: Props) {
         address,
       },
       origin: SendOrigin.AppSendFlow,
+      isMiniPayRecipient: addressToVerifiedBy?.[address] === 'minipay',
     })
   }
 

--- a/packages/wallet-stack/src/send/ValidateRecipientAccount.test.tsx
+++ b/packages/wallet-stack/src/send/ValidateRecipientAccount.test.tsx
@@ -176,6 +176,7 @@ describe('ValidateRecipientAccount', () => {
         ...mockInvitableRecipient2,
         address: mockAccountInvite,
       },
+      isMiniPayRecipient: false,
     })
   })
 })

--- a/packages/wallet-stack/src/send/ValidateRecipientAccount.tsx
+++ b/packages/wallet-stack/src/send/ValidateRecipientAccount.tsx
@@ -42,6 +42,7 @@ interface StateProps {
   validationSuccessful: boolean
   error?: ErrorMessages | null
   validatedAddress?: string
+  isMiniPayRecipient: boolean
 }
 
 interface State {
@@ -77,6 +78,8 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps): StateProps => {
     secureSendPhoneNumberMapping
   )
   const validatedAddress = getSecureSendAddress(recipient, secureSendPhoneNumberMapping)
+  const isMiniPayRecipient =
+    !!validatedAddress && state.identity.addressToVerifiedBy?.[validatedAddress] === 'minipay'
 
   return {
     recipient,
@@ -84,6 +87,7 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps): StateProps => {
     addressValidationType,
     error,
     validatedAddress,
+    isMiniPayRecipient,
   }
 }
 
@@ -121,6 +125,7 @@ export class ValidateRecipientAccount extends React.Component<Props, State> {
         isFromScan: false,
         forceTokenId: route.params.forceTokenId,
         defaultTokenIdOverride: route.params.defaultTokenIdOverride,
+        isMiniPayRecipient: this.props.isMiniPayRecipient,
       })
     }
 

--- a/packages/wallet-stack/test/RootStateSchema.json
+++ b/packages/wallet-stack/test/RootStateSchema.json
@@ -168,6 +168,12 @@
             },
             "type": "object"
         },
+        "AddressToVerifiedByType": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "type": "object"
+        },
         "AddressValidationType": {
             "enum": [
                 "full",
@@ -5558,6 +5564,9 @@
                 "addressToVerificationStatus": {
                     "$ref": "#/definitions/AddressToVerificationStatus"
                 },
+                "addressToVerifiedBy": {
+                    "$ref": "#/definitions/AddressToVerifiedByType"
+                },
                 "askedContactsPermission": {
                     "type": "boolean"
                 },
@@ -5584,6 +5593,7 @@
                 "addressToDisplayName",
                 "addressToE164Number",
                 "addressToVerificationStatus",
+                "addressToVerifiedBy",
                 "askedContactsPermission",
                 "e164NumberToAddress",
                 "importContactsProgress",

--- a/packages/wallet-stack/test/schemas.ts
+++ b/packages/wallet-stack/test/schemas.ts
@@ -3764,6 +3764,18 @@ export const v254Schema = {
   home: _.omit(v253Schema.home, 'hasSeenDivviBottomSheet'),
 }
 
+export const v255Schema = {
+  ...v254Schema,
+  _persist: {
+    ...v254Schema._persist,
+    version: 255,
+  },
+  identity: {
+    ...v254Schema.identity,
+    addressToVerifiedBy: {},
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v254Schema as Partial<RootState>
+  return v255Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Parse `verifiedAddresses` from the `/lookupPhoneNumber` API response to determine which platform verified each resolved address (e.g. `"valora"`, `"minipay"`). When `verifiedAddresses` is present, it is used as the source of truth for resolved addresses — it includes both DB and SocialConnect attestations, while `addresses` only contains DB-verified addresses for backward compatibility.

The `verifiedBy` metadata is stored in a new Redux field (`addressToVerifiedBy`) and used to derive `isMiniPayRecipient`, which is passed to `SendEnterAmount` via nav params for token filtering.

Also replaces the app logo badge on verified recipients with a generic checkmark icon, since recipients can now be verified by different platforms.

### Expected API response shape

```json
{
  "message": "OK",
  "data": {
    "addresses": ["0xabc..."], // <-- existing property used in previous wallet versions
    "verifiedAddresses": [     // <-- new expected property with `verifiedBy` prop
      { "address": "0xabc...", "verifiedBy": "valora" },
      { "address": "0xdef...", "verifiedBy": "minipay" }
    ]
  }
}
```

| Checkmark |
|--------|
| <img width="440" height="956" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-13 at 18 49 37" src="https://github.com/user-attachments/assets/3e80e580-2bd1-49a2-9a98-6ead164dd844" /> | 

### Test plan

- Updated unit test

### Related issues

- Related to https://github.com/celo-org/celo-monorepo/issues/11708
- https://github.com/valora-xyz/wallet-stack/pull/368
- https://github.com/valora-xyz/identity-service/pull/858

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
