### PR TITLE
chore(minipay): refine chip name

### DIFF
--- a/packages/wallet-stack/locales/base/translation.json
+++ b/packages/wallet-stack/locales/base/translation.json
@@ -2269,7 +2269,8 @@
     "insufficientBalanceWarning": {
       "title": "You need more {{tokenSymbol}}",
       "description": "Insufficient {{tokenSymbol}} balance. Try a smaller amount or choose a different asset."
-    }
+    },
+    "miniPayFilterChip": "MiniPay supported"
   },
   "jumpstartIntro": {
     "title": "Share crypto like a text",

--- a/packages/wallet-stack/locales/en-US/translation.json
+++ b/packages/wallet-stack/locales/en-US/translation.json
@@ -2267,8 +2267,7 @@
     "insufficientBalanceWarning": {
       "title": "You need more {{tokenSymbol}}",
       "description": "Insufficient {{tokenSymbol}} balance. Try a smaller amount or choose a different asset."
-    },
-    "miniPayFilterChip": "MiniPay supported"
+    }
   },
   "jumpstartIntro": {
     "title": "Share crypto like a text",

--- a/packages/wallet-stack/locales/en-US/translation.json
+++ b/packages/wallet-stack/locales/en-US/translation.json
@@ -2267,7 +2267,8 @@
     "insufficientBalanceWarning": {
       "title": "You need more {{tokenSymbol}}",
       "description": "Insufficient {{tokenSymbol}} balance. Try a smaller amount or choose a different asset."
-    }
+    },
+    "miniPayFilterChip": "MiniPay supported"
   },
   "jumpstartIntro": {
     "title": "Share crypto like a text",

--- a/packages/wallet-stack/src/send/SendEnterAmount.test.tsx
+++ b/packages/wallet-stack/src/send/SendEnterAmount.test.tsx
@@ -258,7 +258,7 @@ describe('SendEnterAmount', () => {
         </Provider>
       )
 
-      expect(getByText('MiniPay')).toBeTruthy()
+      expect(getByText('sendEnterAmountScreen.miniPayFilterChip')).toBeTruthy()
 
       const tokenBottomSheet = getAllByTestId('TokenBottomSheet')[0]
       const tokens = within(tokenBottomSheet).getAllByTestId('TokenBalanceItem')
@@ -291,7 +291,7 @@ describe('SendEnterAmount', () => {
         </Provider>
       )
 
-      fireEvent.press(getByText('MiniPay'))
+      fireEvent.press(getByText('sendEnterAmountScreen.miniPayFilterChip'))
 
       const tokenBottomSheet = getAllByTestId('TokenBottomSheet')[0]
       const tokens = within(tokenBottomSheet).getAllByTestId('TokenBalanceItem')
@@ -305,7 +305,7 @@ describe('SendEnterAmount', () => {
         </Provider>
       )
 
-      expect(queryByText('MiniPay')).toBeFalsy()
+      expect(queryByText('sendEnterAmountScreen.miniPayFilterChip')).toBeFalsy()
     })
 
     it('should include isMiniPayRecipient in send_amount_continue analytics', async () => {

--- a/packages/wallet-stack/src/send/useSendFilterChips.ts
+++ b/packages/wallet-stack/src/send/useSendFilterChips.ts
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { BooleanFilterChip } from 'src/components/FilterChipsCarousel'
 import { getDynamicConfigParams } from 'src/statsig'
 import { DynamicConfigs } from 'src/statsig/constants'
@@ -18,6 +19,8 @@ export default function useSendFilterChips({
   filterChips: BooleanFilterChip<TokenBalance>[]
   defaultToken: TokenBalance | undefined
 } {
+  const { t } = useTranslation()
+
   const { miniPayTokenIds: configTokenIds } = getDynamicConfigParams(
     DynamicConfigs[StatsigDynamicConfigs.SEND_CONFIG]
   )
@@ -27,7 +30,7 @@ export default function useSendFilterChips({
     ? [
         {
           id: 'minipay',
-          name: 'MiniPay',
+          name: t('sendEnterAmountScreen.miniPayFilterChip'),
           filterFn: (token: TokenBalance) => miniPayTokenIds.includes(token.tokenId),
           isSelected: true,
         },


### PR DESCRIPTION
### Description

Update filter chip name in the send flow from `MiniPay` to `MiniPay supported` following the recent demo feedback.

### Test plan

- Updated unit test

### Related issues

- Related to https://github.com/celo-org/celo-monorepo/issues/11708

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
