### PR TITLE
feat(send): share invite

### DIFF
--- a/packages/wallet-stack/__mocks__/react-native-share.ts
+++ b/packages/wallet-stack/__mocks__/react-native-share.ts
@@ -1,5 +1,5 @@
 const Share = {
-  open: jest.fn().mockResolvedValue({ success: true, dismissedAction: false }),
+  open: jest.fn().mockResolvedValue({ success: true, dismissedAction: false, message: '' }),
 }
 
 export default Share

--- a/packages/wallet-stack/__mocks__/react-native-share.ts
+++ b/packages/wallet-stack/__mocks__/react-native-share.ts
@@ -1,5 +1,5 @@
 const Share = {
-  open: () => {},
+  open: jest.fn().mockResolvedValue({ success: true, dismissedAction: false }),
 }
 
 export default Share

--- a/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
+++ b/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
@@ -367,8 +367,16 @@ describe('SendSelectRecipient', () => {
       .mocked(getRecipientVerificationStatus)
       .mockReturnValue(RecipientVerificationStatus.UNVERIFIED)
 
-    let resolveShare: (value: { success: boolean; dismissedAction: boolean }) => void = () => {}
-    const sharePromise = new Promise<{ success: boolean; dismissedAction: boolean }>((resolve) => {
+    let resolveShare!: (value: {
+      success: boolean
+      dismissedAction: boolean
+      message: string
+    }) => void
+    const sharePromise = new Promise<{
+      success: boolean
+      dismissedAction: boolean
+      message: string
+    }>((resolve) => {
       resolveShare = resolve
     })
     jest.mocked(Share.open).mockReturnValueOnce(sharePromise)
@@ -410,7 +418,7 @@ describe('SendSelectRecipient', () => {
     expect(navigate).not.toHaveBeenCalled()
 
     await act(async () => {
-      resolveShare({ success: true, dismissedAction: false })
+      resolveShare({ success: true, dismissedAction: false, message: '' })
       await sharePromise
     })
   })

--- a/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
+++ b/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
@@ -2,6 +2,7 @@ import Clipboard from '@react-native-clipboard/clipboard'
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
 import * as React from 'react'
 import { Provider } from 'react-redux'
+import Share from 'react-native-share'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { SendEvents } from 'src/analytics/Events'
 import { SendOrigin } from 'src/analytics/types'
@@ -349,6 +350,69 @@ describe('SendSelectRecipient', () => {
     expect(store.getActions()).toEqual([fetchAddressesAndValidate(mockE164Number2Invite)])
     expect(queryByTestId('UnknownAddressInfo')).toBeFalsy()
     expect(getByTestId('SendOrInviteButton')).toBeTruthy()
+  })
+
+  it('opens the platform share sheet and tracks the press analytic before awaiting when inviting an unverified phone number', async () => {
+    const shareUrl = 'https://example.test/invite'
+    jest.mocked(getAppConfig).mockReturnValue({
+      displayName: 'Test App',
+      deepLinkUrlScheme: 'testapp',
+      registryName: 'test',
+      experimental: {
+        phoneNumberVerification: true,
+        inviteFriends: { shareUrl },
+      },
+    })
+    jest
+      .mocked(getRecipientVerificationStatus)
+      .mockReturnValue(RecipientVerificationStatus.UNVERIFIED)
+
+    let resolveShare: (value: { success: boolean; dismissedAction: boolean }) => void = () => {}
+    const sharePromise = new Promise<{ success: boolean; dismissedAction: boolean }>((resolve) => {
+      resolveShare = resolve
+    })
+    jest.mocked(Share.open).mockReturnValueOnce(sharePromise)
+
+    const store = createMockStore(storeWithPhoneVerified)
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <SendSelectRecipient {...mockScreenProps({})} />
+      </Provider>
+    )
+
+    const searchInput = getByTestId('SendSelectRecipientSearchInput')
+    await act(() => {
+      fireEvent.changeText(searchInput, mockE164Number2Invite)
+    })
+    await act(() => {
+      fireEvent.press(getByTestId('RecipientItem'))
+    })
+
+    const button = getByTestId('SendOrInviteButton')
+    expect(button).toHaveTextContent('sendSelectRecipient.buttons.invite', { exact: false })
+
+    await act(() => {
+      fireEvent.press(button)
+    })
+
+    // Analytics fires synchronously on tap, before the share sheet resolves
+    expect(AppAnalytics.track).toHaveBeenCalledWith(SendEvents.send_select_recipient_invite_press, {
+      recipientType: RecipientType.PhoneNumber,
+    })
+    expect(Share.open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(shareUrl),
+        url: shareUrl,
+        failOnCancel: false,
+      })
+    )
+    expect(navigate).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveShare({ success: true, dismissedAction: false })
+      await sharePromise
+    })
   })
 
   it('shows unknown address info text when searching for unknown address after making address verification request', async () => {

--- a/packages/wallet-stack/src/send/SendSelectRecipient.tsx
+++ b/packages/wallet-stack/src/send/SendSelectRecipient.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { getFontScaleSync } from 'react-native-device-info'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import Share, { ShareSingleOptions, Social } from 'react-native-share'
+import Share from 'react-native-share'
 import { isAddressFormat } from 'src/account/utils'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { SendEvents } from 'src/analytics/Events'
@@ -326,21 +326,23 @@ function SendSelectRecipient({ route }: Props) {
     // Invites
     if (shouldInviteRecipient) {
       if (!shareUrl) {
-        Logger.warn('SendSelectRecipient', 'No share URL found for invite with SMS')
+        Logger.warn('SendSelectRecipient', 'No share URL found for invite')
         return
       }
-
-      const shareOptions: ShareSingleOptions = {
-        social: Social.Sms,
-        recipient: recipient.e164PhoneNumber,
-        message: t('inviteWithSmsMessage.shareMessage', { shareUrl }),
-      }
-
-      await Share.shareSingle(shareOptions)
 
       AppAnalytics.track(SendEvents.send_select_recipient_invite_press, {
         recipientType: recipient.recipientType,
       })
+
+      try {
+        await Share.open({
+          message: t('inviteWithSmsMessage.shareMessage', { shareUrl }),
+          url: shareUrl,
+          failOnCancel: false,
+        })
+      } catch (error) {
+        Logger.warn('SendSelectRecipient', 'Share sheet failed', error)
+      }
 
       return
     }


### PR DESCRIPTION
### Description

Take the user to the _Share_ flow instead of creating an SMS, so they can use their preferred messaging channel for sharing.

| Android | iOS |
|--------|--------|
| <img width="1280" height="2856" alt="Screenshot_1776270332" src="https://github.com/user-attachments/assets/618e8e9b-e3f9-44cb-8500-128618cf638b" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-15 at 19 27 59" src="https://github.com/user-attachments/assets/fdeb58d5-3c10-40d8-aa79-4e57275b5e58" /> | 

### Test plan

- Tested manually
- Added unit test

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/11716

### Backwards compatibility

- Changes the way users share the invites

### Network scalability

NA