### PR TITLE
fix(send): infinite spinner on lookup error

### DIFF
--- a/packages/wallet-stack/src/identity/actions.ts
+++ b/packages/wallet-stack/src/identity/actions.ts
@@ -58,9 +58,9 @@ export interface FetchAddressVerificationAction {
   address: string
 }
 
-export type LookupKind = 'phoneNumber' | 'address'
+type LookupKind = 'phoneNumber' | 'address'
 
-export interface LookupSetLoadingAction {
+interface LookupSetLoadingAction {
   type: Actions.LOOKUP_SET_LOADING
   kind: LookupKind
   key: string

--- a/packages/wallet-stack/src/identity/actions.ts
+++ b/packages/wallet-stack/src/identity/actions.ts
@@ -15,7 +15,7 @@ export enum Actions {
   CANCEL_IMPORT_CONTACTS = 'IDENTITY/CANCEL_IMPORT_CONTACTS',
   END_IMPORT_CONTACTS = 'IDENTITY/END_IMPORT_CONTACTS',
   FETCH_ADDRESS_VERIFICATION_STATUS = 'IDENTITY/FETCH_ADDRESS_VERIFICATION_STATUS',
-  LOOKUP_SET_LOADING = 'IDENTITY/LOOKUP_SET_LOADING',
+  RECIPIENT_LOOKUP_RESOLVED = 'IDENTITY/RECIPIENT_LOOKUP_RESOLVED',
   CONTACTS_SAVED = 'IDENTITY/CONTACTS_SAVED',
   STORED_PASSWORD_REFRESHED = 'IDENTITY/STORED_PASSWORD_REFRESHED',
 }
@@ -58,13 +58,8 @@ export interface FetchAddressVerificationAction {
   address: string
 }
 
-type LookupKind = 'phoneNumber' | 'address'
-
-interface LookupSetLoadingAction {
-  type: Actions.LOOKUP_SET_LOADING
-  kind: LookupKind
-  key: string
-  loading: boolean
+interface RecipientLookupResolvedAction {
+  type: Actions.RECIPIENT_LOOKUP_RESOLVED
 }
 
 interface ContactsSavedAction {
@@ -84,7 +79,7 @@ export type ActionTypes =
   | EndImportContactsAction
   | FetchAddressesAndValidateAction
   | FetchAddressVerificationAction
-  | LookupSetLoadingAction
+  | RecipientLookupResolvedAction
   | ContactsSavedAction
   | StoredPasswordRefreshedAction
 
@@ -98,15 +93,8 @@ export const fetchAddressVerification = (address: string): FetchAddressVerificat
   address,
 })
 
-export const lookupSetLoading = (
-  kind: LookupKind,
-  key: string,
-  loading: boolean
-): LookupSetLoadingAction => ({
-  type: Actions.LOOKUP_SET_LOADING,
-  kind,
-  key,
-  loading,
+export const recipientLookupResolved = (): RecipientLookupResolvedAction => ({
+  type: Actions.RECIPIENT_LOOKUP_RESOLVED,
 })
 
 export const updateE164PhoneNumberAddresses = (

--- a/packages/wallet-stack/src/identity/actions.ts
+++ b/packages/wallet-stack/src/identity/actions.ts
@@ -15,6 +15,7 @@ export enum Actions {
   CANCEL_IMPORT_CONTACTS = 'IDENTITY/CANCEL_IMPORT_CONTACTS',
   END_IMPORT_CONTACTS = 'IDENTITY/END_IMPORT_CONTACTS',
   FETCH_ADDRESS_VERIFICATION_STATUS = 'IDENTITY/FETCH_ADDRESS_VERIFICATION_STATUS',
+  LOOKUP_SET_LOADING = 'IDENTITY/LOOKUP_SET_LOADING',
   CONTACTS_SAVED = 'IDENTITY/CONTACTS_SAVED',
   STORED_PASSWORD_REFRESHED = 'IDENTITY/STORED_PASSWORD_REFRESHED',
 }
@@ -57,6 +58,15 @@ export interface FetchAddressVerificationAction {
   address: string
 }
 
+export type LookupKind = 'phoneNumber' | 'address'
+
+export interface LookupSetLoadingAction {
+  type: Actions.LOOKUP_SET_LOADING
+  kind: LookupKind
+  key: string
+  loading: boolean
+}
+
 interface ContactsSavedAction {
   type: Actions.CONTACTS_SAVED
   hash: string
@@ -74,6 +84,7 @@ export type ActionTypes =
   | EndImportContactsAction
   | FetchAddressesAndValidateAction
   | FetchAddressVerificationAction
+  | LookupSetLoadingAction
   | ContactsSavedAction
   | StoredPasswordRefreshedAction
 
@@ -85,6 +96,17 @@ export const fetchAddressesAndValidate = (e164Number: string): FetchAddressesAnd
 export const fetchAddressVerification = (address: string): FetchAddressVerificationAction => ({
   type: Actions.FETCH_ADDRESS_VERIFICATION_STATUS,
   address,
+})
+
+export const lookupSetLoading = (
+  kind: LookupKind,
+  key: string,
+  loading: boolean
+): LookupSetLoadingAction => ({
+  type: Actions.LOOKUP_SET_LOADING,
+  kind,
+  key,
+  loading,
 })
 
 export const updateE164PhoneNumberAddresses = (

--- a/packages/wallet-stack/src/identity/contactMapping.test.ts
+++ b/packages/wallet-stack/src/identity/contactMapping.test.ts
@@ -15,6 +15,7 @@ import {
   contactsSaved,
   fetchAddressVerification,
   fetchAddressesAndValidate,
+  lookupSetLoading,
   updateE164PhoneNumberAddresses,
 } from 'src/identity/actions'
 import {
@@ -110,6 +111,7 @@ describe('Fetch Addresses Saga', () => {
           [select(walletAddressSelector), '0xxyz'],
           [call(retrieveSignedMessage), 'some signed message'],
         ])
+        .put(lookupSetLoading('phoneNumber', mockE164Number, true))
         .put(updateE164PhoneNumberAddresses({ [mockE164Number]: undefined }, {}))
         .put(
           updateE164PhoneNumberAddresses(
@@ -118,6 +120,7 @@ describe('Fetch Addresses Saga', () => {
             {}
           )
         )
+        .put(lookupSetLoading('phoneNumber', mockE164Number, false))
         .run()
 
       expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -227,7 +230,9 @@ describe('Fetch Addresses Saga', () => {
           [select(walletAddressSelector), '0xxyz'],
           [call(retrieveSignedMessage), 'some signed message'],
         ])
+        .put(lookupSetLoading('phoneNumber', mockE164Number, true))
         .put(showErrorOrFallback(expect.anything(), ErrorMessages.ADDRESS_LOOKUP_FAILURE))
+        .put(lookupSetLoading('phoneNumber', mockE164Number, false))
         .run()
     })
   })
@@ -248,7 +253,9 @@ describe('Fetch Address Verification Saga', () => {
         [select(walletAddressSelector), '0xxyz'],
         [call(retrieveSignedMessage), 'some signed message'],
       ])
+      .put(lookupSetLoading('address', mockAccount.toLowerCase(), true))
       .put(updateE164PhoneNumberAddresses({}, {}, { [mockAccount.toLowerCase()]: 'minipay' }))
+      .put(lookupSetLoading('address', mockAccount.toLowerCase(), false))
       .run()
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -295,7 +302,9 @@ describe('Fetch Address Verification Saga', () => {
         [call(retrieveSignedMessage), 'some signed message'],
       ])
       .not.put.actionType(Actions.UPDATE_E164_PHONE_NUMBER_ADDRESSES)
+      .put(lookupSetLoading('address', mockAccount.toLowerCase(), true))
       .put(showErrorOrFallback(expect.anything(), ErrorMessages.ADDRESS_LOOKUP_FAILURE))
+      .put(lookupSetLoading('address', mockAccount.toLowerCase(), false))
       .run()
     expect(AppAnalytics.track).toHaveBeenCalledWith(IdentityEvents.address_lookup_error, {
       error: 'Unable to fetch verification status for this address',

--- a/packages/wallet-stack/src/identity/contactMapping.test.ts
+++ b/packages/wallet-stack/src/identity/contactMapping.test.ts
@@ -15,7 +15,7 @@ import {
   contactsSaved,
   fetchAddressVerification,
   fetchAddressesAndValidate,
-  lookupSetLoading,
+  recipientLookupResolved,
   updateE164PhoneNumberAddresses,
 } from 'src/identity/actions'
 import {
@@ -111,7 +111,6 @@ describe('Fetch Addresses Saga', () => {
           [select(walletAddressSelector), '0xxyz'],
           [call(retrieveSignedMessage), 'some signed message'],
         ])
-        .put(lookupSetLoading('phoneNumber', mockE164Number, true))
         .put(updateE164PhoneNumberAddresses({ [mockE164Number]: undefined }, {}))
         .put(
           updateE164PhoneNumberAddresses(
@@ -120,7 +119,7 @@ describe('Fetch Addresses Saga', () => {
             {}
           )
         )
-        .put(lookupSetLoading('phoneNumber', mockE164Number, false))
+        .put(recipientLookupResolved())
         .run()
 
       expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -230,9 +229,8 @@ describe('Fetch Addresses Saga', () => {
           [select(walletAddressSelector), '0xxyz'],
           [call(retrieveSignedMessage), 'some signed message'],
         ])
-        .put(lookupSetLoading('phoneNumber', mockE164Number, true))
         .put(showErrorOrFallback(expect.anything(), ErrorMessages.ADDRESS_LOOKUP_FAILURE))
-        .put(lookupSetLoading('phoneNumber', mockE164Number, false))
+        .put(recipientLookupResolved())
         .run()
     })
   })
@@ -253,9 +251,8 @@ describe('Fetch Address Verification Saga', () => {
         [select(walletAddressSelector), '0xxyz'],
         [call(retrieveSignedMessage), 'some signed message'],
       ])
-      .put(lookupSetLoading('address', mockAccount.toLowerCase(), true))
       .put(updateE164PhoneNumberAddresses({}, {}, { [mockAccount.toLowerCase()]: 'minipay' }))
-      .put(lookupSetLoading('address', mockAccount.toLowerCase(), false))
+      .put(recipientLookupResolved())
       .run()
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -302,9 +299,8 @@ describe('Fetch Address Verification Saga', () => {
         [call(retrieveSignedMessage), 'some signed message'],
       ])
       .not.put.actionType(Actions.UPDATE_E164_PHONE_NUMBER_ADDRESSES)
-      .put(lookupSetLoading('address', mockAccount.toLowerCase(), true))
       .put(showErrorOrFallback(expect.anything(), ErrorMessages.ADDRESS_LOOKUP_FAILURE))
-      .put(lookupSetLoading('address', mockAccount.toLowerCase(), false))
+      .put(recipientLookupResolved())
       .run()
     expect(AppAnalytics.track).toHaveBeenCalledWith(IdentityEvents.address_lookup_error, {
       error: 'Unable to fetch verification status for this address',

--- a/packages/wallet-stack/src/identity/contactMapping.ts
+++ b/packages/wallet-stack/src/identity/contactMapping.ts
@@ -13,7 +13,7 @@ import {
   FetchAddressesAndValidateAction,
   contactsSaved,
   endImportContacts,
-  lookupSetLoading,
+  recipientLookupResolved,
   updateE164PhoneNumberAddresses,
   updateImportContactsProgress,
 } from 'src/identity/actions'
@@ -142,7 +142,6 @@ function* updateUserContact(e164NumberToRecipients: NumberToRecipient) {
 
 export function* fetchAddressesAndValidateSaga({ e164Number }: FetchAddressesAndValidateAction) {
   AppAnalytics.track(IdentityEvents.phone_number_lookup_start)
-  yield* put(lookupSetLoading('phoneNumber', e164Number, true))
   try {
     Logger.debug(TAG + '@fetchAddressesAndValidate', `Fetching addresses for number`)
 
@@ -215,13 +214,12 @@ export function* fetchAddressesAndValidateSaga({ e164Number }: FetchAddressesAnd
       error: error.message,
     })
   } finally {
-    yield* put(lookupSetLoading('phoneNumber', e164Number, false))
+    yield* put(recipientLookupResolved())
   }
 }
 
 export function* fetchAddressVerificationSaga({ address }: FetchAddressVerificationAction) {
   const normalizedAddress = address.toLowerCase()
-  yield* put(lookupSetLoading('address', normalizedAddress, true))
   try {
     AppAnalytics.track(IdentityEvents.address_lookup_start)
     const { addressVerified, verifiedBy } = yield* call(fetchAddressVerification, normalizedAddress)
@@ -245,7 +243,7 @@ export function* fetchAddressVerificationSaga({ address }: FetchAddressVerificat
     yield* put(showErrorOrFallback(error, ErrorMessages.ADDRESS_LOOKUP_FAILURE))
     AppAnalytics.track(IdentityEvents.address_lookup_error, { error: error.message })
   } finally {
-    yield* put(lookupSetLoading('address', normalizedAddress, false))
+    yield* put(recipientLookupResolved())
   }
 }
 

--- a/packages/wallet-stack/src/identity/contactMapping.ts
+++ b/packages/wallet-stack/src/identity/contactMapping.ts
@@ -13,6 +13,7 @@ import {
   FetchAddressesAndValidateAction,
   contactsSaved,
   endImportContacts,
+  lookupSetLoading,
   updateE164PhoneNumberAddresses,
   updateImportContactsProgress,
 } from 'src/identity/actions'
@@ -141,6 +142,7 @@ function* updateUserContact(e164NumberToRecipients: NumberToRecipient) {
 
 export function* fetchAddressesAndValidateSaga({ e164Number }: FetchAddressesAndValidateAction) {
   AppAnalytics.track(IdentityEvents.phone_number_lookup_start)
+  yield* put(lookupSetLoading('phoneNumber', e164Number, true))
   try {
     Logger.debug(TAG + '@fetchAddressesAndValidate', `Fetching addresses for number`)
 
@@ -212,11 +214,14 @@ export function* fetchAddressesAndValidateSaga({ e164Number }: FetchAddressesAnd
     AppAnalytics.track(IdentityEvents.phone_number_lookup_error, {
       error: error.message,
     })
+  } finally {
+    yield* put(lookupSetLoading('phoneNumber', e164Number, false))
   }
 }
 
 export function* fetchAddressVerificationSaga({ address }: FetchAddressVerificationAction) {
   const normalizedAddress = address.toLowerCase()
+  yield* put(lookupSetLoading('address', normalizedAddress, true))
   try {
     AppAnalytics.track(IdentityEvents.address_lookup_start)
     const { addressVerified, verifiedBy } = yield* call(fetchAddressVerification, normalizedAddress)
@@ -239,6 +244,8 @@ export function* fetchAddressVerificationSaga({ address }: FetchAddressVerificat
     )
     yield* put(showErrorOrFallback(error, ErrorMessages.ADDRESS_LOOKUP_FAILURE))
     AppAnalytics.track(IdentityEvents.address_lookup_error, { error: error.message })
+  } finally {
+    yield* put(lookupSetLoading('address', normalizedAddress, false))
   }
 }
 

--- a/packages/wallet-stack/src/identity/reducer.test.ts
+++ b/packages/wallet-stack/src/identity/reducer.test.ts
@@ -1,54 +1,29 @@
-import { Actions, lookupSetLoading } from 'src/identity/actions'
+import {
+  Actions,
+  fetchAddressVerification,
+  fetchAddressesAndValidate,
+  recipientLookupResolved,
+} from 'src/identity/actions'
 import { reducer } from 'src/identity/reducer'
 
 const initialState = reducer(undefined, { type: 'INIT' } as any)
 
 describe('identity reducer', () => {
-  describe(Actions.LOOKUP_SET_LOADING, () => {
-    it('marks a phone number as loading', () => {
-      const next = reducer(initialState, lookupSetLoading('phoneNumber', '+15551234567', true))
-      expect(next.lookupLoading).toEqual({
-        phoneNumber: { '+15551234567': true },
-        address: {},
-      })
+  describe('recipientLookupLoading', () => {
+    it(`is set true on ${Actions.FETCH_ADDRESSES_AND_VALIDATION_STATUS}`, () => {
+      const next = reducer(initialState, fetchAddressesAndValidate('+15551234567'))
+      expect(next.recipientLookupLoading).toBe(true)
     })
 
-    it('marks an address as loading', () => {
-      const next = reducer(initialState, lookupSetLoading('address', '0xabc', true))
-      expect(next.lookupLoading).toEqual({
-        phoneNumber: {},
-        address: { '0xabc': true },
-      })
+    it(`is set true on ${Actions.FETCH_ADDRESS_VERIFICATION_STATUS}`, () => {
+      const next = reducer(initialState, fetchAddressVerification('0xabc'))
+      expect(next.recipientLookupLoading).toBe(true)
     })
 
-    it('clears the loading flag for a single key without touching others', () => {
-      const loadingState = {
-        ...initialState,
-        lookupLoading: {
-          phoneNumber: { '+15551234567': true, '+15559999999': true },
-          address: { '0xabc': true },
-        },
-      }
-      const next = reducer(loadingState, lookupSetLoading('phoneNumber', '+15551234567', false))
-      expect(next.lookupLoading).toEqual({
-        phoneNumber: { '+15551234567': false, '+15559999999': true },
-        address: { '0xabc': true },
-      })
-    })
-
-    it('keeps the two kinds isolated when updating one', () => {
-      const loadingState = {
-        ...initialState,
-        lookupLoading: {
-          phoneNumber: { '+15551234567': true },
-          address: {},
-        },
-      }
-      const next = reducer(loadingState, lookupSetLoading('address', '0xabc', true))
-      expect(next.lookupLoading).toEqual({
-        phoneNumber: { '+15551234567': true },
-        address: { '0xabc': true },
-      })
+    it(`is cleared on ${Actions.RECIPIENT_LOOKUP_RESOLVED}`, () => {
+      const loadingState = { ...initialState, recipientLookupLoading: true }
+      const next = reducer(loadingState, recipientLookupResolved())
+      expect(next.recipientLookupLoading).toBe(false)
     })
   })
 })

--- a/packages/wallet-stack/src/identity/reducer.test.ts
+++ b/packages/wallet-stack/src/identity/reducer.test.ts
@@ -1,0 +1,54 @@
+import { Actions, lookupSetLoading } from 'src/identity/actions'
+import { reducer } from 'src/identity/reducer'
+
+const initialState = reducer(undefined, { type: 'INIT' } as any)
+
+describe('identity reducer', () => {
+  describe(Actions.LOOKUP_SET_LOADING, () => {
+    it('marks a phone number as loading', () => {
+      const next = reducer(initialState, lookupSetLoading('phoneNumber', '+15551234567', true))
+      expect(next.lookupLoading).toEqual({
+        phoneNumber: { '+15551234567': true },
+        address: {},
+      })
+    })
+
+    it('marks an address as loading', () => {
+      const next = reducer(initialState, lookupSetLoading('address', '0xabc', true))
+      expect(next.lookupLoading).toEqual({
+        phoneNumber: {},
+        address: { '0xabc': true },
+      })
+    })
+
+    it('clears the loading flag for a single key without touching others', () => {
+      const loadingState = {
+        ...initialState,
+        lookupLoading: {
+          phoneNumber: { '+15551234567': true, '+15559999999': true },
+          address: { '0xabc': true },
+        },
+      }
+      const next = reducer(loadingState, lookupSetLoading('phoneNumber', '+15551234567', false))
+      expect(next.lookupLoading).toEqual({
+        phoneNumber: { '+15551234567': false, '+15559999999': true },
+        address: { '0xabc': true },
+      })
+    })
+
+    it('keeps the two kinds isolated when updating one', () => {
+      const loadingState = {
+        ...initialState,
+        lookupLoading: {
+          phoneNumber: { '+15551234567': true },
+          address: {},
+        },
+      }
+      const next = reducer(loadingState, lookupSetLoading('address', '0xabc', true))
+      expect(next.lookupLoading).toEqual({
+        phoneNumber: { '+15551234567': true },
+        address: { '0xabc': true },
+      })
+    })
+  })
+})

--- a/packages/wallet-stack/src/identity/reducer.ts
+++ b/packages/wallet-stack/src/identity/reducer.ts
@@ -38,6 +38,11 @@ export interface AddressToVerifiedByType {
   [address: string]: string | null | undefined
 }
 
+export interface LookupLoadingType {
+  phoneNumber: { [e164PhoneNumber: string]: boolean | undefined }
+  address: { [address: string]: boolean | undefined }
+}
+
 interface State {
   addressToE164Number: AddressToE164NumberType
   // Note: Do not access values in this directly, use the `getAddressFromPhoneNumber` helper in contactMapping
@@ -49,6 +54,10 @@ interface State {
   importContactsProgress: ImportContactProgress
   // Mapping of address to the entity that verified it (e.g. "valora", "minipay")
   addressToVerifiedBy: AddressToVerifiedByType
+  // Per-key flags indicating an in-flight identity lookup. `phoneNumber` is keyed by E.164
+  // (set by `fetchAddressesAndValidate`); `address` is keyed by lower-cased address (set by
+  // `fetchAddressVerification`). Each saga sets its flag at start and clears it in `finally`.
+  lookupLoading: LookupLoadingType
   lastSavedContactsHash: string | null
   shouldRefreshStoredPasswordHash: boolean
 }
@@ -64,6 +73,7 @@ const initialState: State = {
     total: 0,
   },
   addressToVerifiedBy: {},
+  lookupLoading: { phoneNumber: {}, address: {} },
   lastSavedContactsHash: null,
   shouldRefreshStoredPasswordHash: false,
 }
@@ -145,6 +155,17 @@ export const reducer = (
         addressToVerifiedBy: {
           ...state.addressToVerifiedBy,
           [action.address]: undefined,
+        },
+      }
+    case Actions.LOOKUP_SET_LOADING:
+      return {
+        ...state,
+        lookupLoading: {
+          ...state.lookupLoading,
+          [action.kind]: {
+            ...state.lookupLoading[action.kind],
+            [action.key]: action.loading,
+          },
         },
       }
     case Actions.CONTACTS_SAVED:

--- a/packages/wallet-stack/src/identity/reducer.ts
+++ b/packages/wallet-stack/src/identity/reducer.ts
@@ -38,11 +38,6 @@ export interface AddressToVerifiedByType {
   [address: string]: string | null | undefined
 }
 
-interface LookupLoadingType {
-  phoneNumber: { [e164PhoneNumber: string]: boolean | undefined }
-  address: { [address: string]: boolean | undefined }
-}
-
 interface State {
   addressToE164Number: AddressToE164NumberType
   // Note: Do not access values in this directly, use the `getAddressFromPhoneNumber` helper in contactMapping
@@ -54,10 +49,8 @@ interface State {
   importContactsProgress: ImportContactProgress
   // Mapping of address to the entity that verified it (e.g. "valora", "minipay")
   addressToVerifiedBy: AddressToVerifiedByType
-  // Per-key flags indicating an in-flight identity lookup. `phoneNumber` is keyed by E.164
-  // (set by `fetchAddressesAndValidate`); `address` is keyed by lower-cased address (set by
-  // `fetchAddressVerification`). Each saga sets its flag at start and clears it in `finally`.
-  lookupLoading: LookupLoadingType
+  // Single boolean is safe because both lookup sagas use `takeLatest` — at most one in flight.
+  recipientLookupLoading: boolean
   lastSavedContactsHash: string | null
   shouldRefreshStoredPasswordHash: boolean
 }
@@ -73,7 +66,7 @@ const initialState: State = {
     total: 0,
   },
   addressToVerifiedBy: {},
-  lookupLoading: { phoneNumber: {}, address: {} },
+  recipientLookupLoading: false,
   lastSavedContactsHash: null,
   shouldRefreshStoredPasswordHash: false,
 }
@@ -95,6 +88,7 @@ export const reducer = (
           current: 0,
           total: 0,
         },
+        recipientLookupLoading: false,
       }
     }
     case Actions.UPDATE_E164_PHONE_NUMBER_ADDRESSES:
@@ -149,6 +143,11 @@ export const reducer = (
         addressToE164Number: state.addressToE164Number,
         e164NumberToAddress: state.e164NumberToAddress,
       }
+    case Actions.FETCH_ADDRESSES_AND_VALIDATION_STATUS:
+      return {
+        ...state,
+        recipientLookupLoading: true,
+      }
     case Actions.FETCH_ADDRESS_VERIFICATION_STATUS:
       return {
         ...state,
@@ -156,17 +155,12 @@ export const reducer = (
           ...state.addressToVerifiedBy,
           [action.address]: undefined,
         },
+        recipientLookupLoading: true,
       }
-    case Actions.LOOKUP_SET_LOADING:
+    case Actions.RECIPIENT_LOOKUP_RESOLVED:
       return {
         ...state,
-        lookupLoading: {
-          ...state.lookupLoading,
-          [action.kind]: {
-            ...state.lookupLoading[action.kind],
-            [action.key]: action.loading,
-          },
-        },
+        recipientLookupLoading: false,
       }
     case Actions.CONTACTS_SAVED:
       return {

--- a/packages/wallet-stack/src/identity/reducer.ts
+++ b/packages/wallet-stack/src/identity/reducer.ts
@@ -38,7 +38,7 @@ export interface AddressToVerifiedByType {
   [address: string]: string | null | undefined
 }
 
-export interface LookupLoadingType {
+interface LookupLoadingType {
   phoneNumber: { [e164PhoneNumber: string]: boolean | undefined }
   address: { [address: string]: boolean | undefined }
 }

--- a/packages/wallet-stack/src/identity/saga.ts
+++ b/packages/wallet-stack/src/identity/saga.ts
@@ -7,7 +7,7 @@ import {
 import { Actions } from 'src/identity/actions'
 import Logger from 'src/utils/Logger'
 import { safely } from 'src/utils/safely'
-import { cancelled, spawn, takeEvery, takeLatest, takeLeading } from 'typed-redux-saga'
+import { cancelled, spawn, takeLatest, takeLeading } from 'typed-redux-saga'
 
 const TAG = 'identity/saga'
 
@@ -20,7 +20,7 @@ function* watchContactMapping() {
 }
 
 function* watchFetchAddressVerification() {
-  yield* takeEvery(Actions.FETCH_ADDRESS_VERIFICATION_STATUS, safely(fetchAddressVerificationSaga))
+  yield* takeLatest(Actions.FETCH_ADDRESS_VERIFICATION_STATUS, safely(fetchAddressVerificationSaga))
 }
 
 export function* identitySaga() {

--- a/packages/wallet-stack/src/identity/selectors.ts
+++ b/packages/wallet-stack/src/identity/selectors.ts
@@ -3,7 +3,8 @@ import { RootState } from 'src/redux/reducers'
 export const e164NumberToAddressSelector = (state: RootState) => state.identity.e164NumberToAddress
 export const addressToE164NumberSelector = (state: RootState) => state.identity.addressToE164Number
 export const addressToVerifiedBySelector = (state: RootState) => state.identity.addressToVerifiedBy
-export const lookupLoadingSelector = (state: RootState) => state.identity.lookupLoading
+export const recipientLookupLoadingSelector = (state: RootState) =>
+  state.identity.recipientLookupLoading
 export const importContactsProgressSelector = (state: RootState) =>
   state.identity.importContactsProgress
 export const addressToDisplayNameSelector = (state: RootState) =>

--- a/packages/wallet-stack/src/identity/selectors.ts
+++ b/packages/wallet-stack/src/identity/selectors.ts
@@ -3,6 +3,7 @@ import { RootState } from 'src/redux/reducers'
 export const e164NumberToAddressSelector = (state: RootState) => state.identity.e164NumberToAddress
 export const addressToE164NumberSelector = (state: RootState) => state.identity.addressToE164Number
 export const addressToVerifiedBySelector = (state: RootState) => state.identity.addressToVerifiedBy
+export const lookupLoadingSelector = (state: RootState) => state.identity.lookupLoading
 export const importContactsProgressSelector = (state: RootState) =>
   state.identity.importContactsProgress
 export const addressToDisplayNameSelector = (state: RootState) =>

--- a/packages/wallet-stack/src/redux/migrations.ts
+++ b/packages/wallet-stack/src/redux/migrations.ts
@@ -2106,7 +2106,7 @@ export const migrations = {
     ...state,
     identity: {
       ...state.identity,
-      lookupLoading: { phoneNumber: {}, address: {} },
+      recipientLookupLoading: false,
     },
   }),
 }

--- a/packages/wallet-stack/src/redux/migrations.ts
+++ b/packages/wallet-stack/src/redux/migrations.ts
@@ -2102,4 +2102,11 @@ export const migrations = {
       },
     }
   },
+  258: (state: any) => ({
+    ...state,
+    identity: {
+      ...state.identity,
+      lookupLoading: { phoneNumber: {}, address: {} },
+    },
+  }),
 }

--- a/packages/wallet-stack/src/redux/store.test.ts
+++ b/packages/wallet-stack/src/redux/store.test.ts
@@ -7,7 +7,12 @@ import * as createMigrateModule from 'src/redux/createMigrate'
 import { migrations } from 'src/redux/migrations'
 import { RootState } from 'src/redux/reducers'
 import { rootSaga } from 'src/redux/sagas'
-import { _persistConfig, setupStore, timeBetweenStoreSizeEvents } from 'src/redux/store'
+import {
+  _persistConfig,
+  setupStore,
+  stripIdentityTransients,
+  timeBetweenStoreSizeEvents,
+} from 'src/redux/store'
 import * as accountCheckerModule from 'src/utils/accountChecker'
 import Logger from 'src/utils/Logger'
 import { getLatestSchema, vNeg1Schema } from 'test/schemas'
@@ -102,6 +107,42 @@ describe('persistConfig', () => {
   })
 })
 
+describe('stripIdentityTransients', () => {
+  const baseIdentityState = {
+    addressToE164Number: { '0xabc': '+15551234567' },
+    e164NumberToAddress: { '+15551234567': ['0xabc'] },
+    addressToDisplayName: {},
+    askedContactsPermission: false,
+    importContactsProgress: { status: 0, current: 0, total: 0 },
+    addressToVerifiedBy: { '0xabc': 'valora' },
+    lookupLoading: {
+      phoneNumber: { '+15551234567': true, '+15559999999': false },
+      address: { '0xabc': true, '0xdef': false },
+    },
+    lastSavedContactsHash: null,
+    shouldRefreshStoredPasswordHash: false,
+  } as any
+
+  it('strips lookupLoading from identity when serializing to storage', () => {
+    // redux-persist's createTransform: `in` runs on state → storage, `out` runs on storage → state.
+    const persisted = stripIdentityTransients.in(baseIdentityState, 'identity', baseIdentityState)
+    expect(persisted).not.toHaveProperty('lookupLoading')
+    // Other identity fields are preserved
+    expect(persisted).toMatchObject({
+      addressToE164Number: { '0xabc': '+15551234567' },
+      e164NumberToAddress: { '+15551234567': ['0xabc'] },
+      addressToVerifiedBy: { '0xabc': 'valora' },
+    })
+  })
+
+  it('passes the storage → state path through unchanged', () => {
+    const stored = { ...baseIdentityState }
+    delete stored.lookupLoading
+    const restored = stripIdentityTransients.out(stored, 'identity', stored)
+    expect(restored).toEqual(stored)
+  })
+})
+
 describe('store state', () => {
   // This test ensures the vNeg1Schema can be successfully migrated to the latest version
   // and validates against the latest RootState schema
@@ -143,7 +184,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 257,
+          "version": 258,
         },
         "account": {
           "acceptedTerms": false,
@@ -253,6 +294,10 @@ describe('store state', () => {
             "total": 0,
           },
           "lastSavedContactsHash": null,
+          "lookupLoading": {
+            "address": {},
+            "phoneNumber": {},
+          },
           "shouldRefreshStoredPasswordHash": true,
         },
         "imports": {

--- a/packages/wallet-stack/src/redux/store.test.ts
+++ b/packages/wallet-stack/src/redux/store.test.ts
@@ -7,12 +7,7 @@ import * as createMigrateModule from 'src/redux/createMigrate'
 import { migrations } from 'src/redux/migrations'
 import { RootState } from 'src/redux/reducers'
 import { rootSaga } from 'src/redux/sagas'
-import {
-  _persistConfig,
-  setupStore,
-  stripIdentityTransients,
-  timeBetweenStoreSizeEvents,
-} from 'src/redux/store'
+import { _persistConfig, setupStore, timeBetweenStoreSizeEvents } from 'src/redux/store'
 import * as accountCheckerModule from 'src/utils/accountChecker'
 import Logger from 'src/utils/Logger'
 import { getLatestSchema, vNeg1Schema } from 'test/schemas'
@@ -104,42 +99,6 @@ describe('persistConfig', () => {
     expect(AppAnalytics.track).toHaveBeenCalledWith(PerformanceEvents.redux_store_size, {
       size: 41,
     })
-  })
-})
-
-describe('stripIdentityTransients', () => {
-  const baseIdentityState = {
-    addressToE164Number: { '0xabc': '+15551234567' },
-    e164NumberToAddress: { '+15551234567': ['0xabc'] },
-    addressToDisplayName: {},
-    askedContactsPermission: false,
-    importContactsProgress: { status: 0, current: 0, total: 0 },
-    addressToVerifiedBy: { '0xabc': 'valora' },
-    lookupLoading: {
-      phoneNumber: { '+15551234567': true, '+15559999999': false },
-      address: { '0xabc': true, '0xdef': false },
-    },
-    lastSavedContactsHash: null,
-    shouldRefreshStoredPasswordHash: false,
-  } as any
-
-  it('strips lookupLoading from identity when serializing to storage', () => {
-    // redux-persist's createTransform: `in` runs on state → storage, `out` runs on storage → state.
-    const persisted = stripIdentityTransients.in(baseIdentityState, 'identity', baseIdentityState)
-    expect(persisted).not.toHaveProperty('lookupLoading')
-    // Other identity fields are preserved
-    expect(persisted).toMatchObject({
-      addressToE164Number: { '0xabc': '+15551234567' },
-      e164NumberToAddress: { '+15551234567': ['0xabc'] },
-      addressToVerifiedBy: { '0xabc': 'valora' },
-    })
-  })
-
-  it('passes the storage → state path through unchanged', () => {
-    const stored = { ...baseIdentityState }
-    delete stored.lookupLoading
-    const restored = stripIdentityTransients.out(stored, 'identity', stored)
-    expect(restored).toEqual(stored)
   })
 })
 
@@ -294,10 +253,7 @@ describe('store state', () => {
             "total": 0,
           },
           "lastSavedContactsHash": null,
-          "lookupLoading": {
-            "address": {},
-            "phoneNumber": {},
-          },
+          "recipientLookupLoading": false,
           "shouldRefreshStoredPasswordHash": true,
         },
         "imports": {

--- a/packages/wallet-stack/src/redux/store.ts
+++ b/packages/wallet-stack/src/redux/store.ts
@@ -2,7 +2,13 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { configureStore, Middleware } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/query'
 import devToolsEnhancer from 'redux-devtools-expo-dev-plugin'
-import { getStoredState, PersistConfig, persistReducer, persistStore } from 'redux-persist'
+import {
+  createTransform,
+  getStoredState,
+  PersistConfig,
+  persistReducer,
+  persistStore,
+} from 'redux-persist'
 import FSStorage from 'redux-persist-fs-storage'
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2'
 import AppAnalytics from 'src/analytics/AppAnalytics'
@@ -26,14 +32,30 @@ export const timeBetweenStoreSizeEvents = ONE_MINUTE_IN_MILLIS
 // the entire state is serialized in a session
 let lastEventTime = 0
 
+// Strip transient identity fields before they hit storage. `lookupLoading` tracks whether a
+// lookup saga is currently in flight — only meaningful within a single session, so persisting
+// it would just create churn and risk restoring a phantom in-flight flag after a crash mid-fetch.
+export const stripIdentityTransients = createTransform<
+  ReducersRootState['identity'],
+  Omit<ReducersRootState['identity'], 'lookupLoading'>
+>(
+  (inboundState) => {
+    const { lookupLoading: _drop, ...persistable } = inboundState
+    return persistable
+  },
+  (outboundState) => outboundState as ReducersRootState['identity'],
+  { whitelist: ['identity'] }
+)
+
 const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-xyz/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 257,
+  version: 258,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],
+  transforms: [stripIdentityTransients],
   stateReconciler: autoMergeLevel2,
   migrate: async (...args) => {
     const migrate = createMigrate(migrations)

--- a/packages/wallet-stack/src/redux/store.ts
+++ b/packages/wallet-stack/src/redux/store.ts
@@ -2,13 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { configureStore, Middleware } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/query'
 import devToolsEnhancer from 'redux-devtools-expo-dev-plugin'
-import {
-  createTransform,
-  getStoredState,
-  PersistConfig,
-  persistReducer,
-  persistStore,
-} from 'redux-persist'
+import { getStoredState, PersistConfig, persistReducer, persistStore } from 'redux-persist'
 import FSStorage from 'redux-persist-fs-storage'
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2'
 import AppAnalytics from 'src/analytics/AppAnalytics'
@@ -32,21 +26,6 @@ export const timeBetweenStoreSizeEvents = ONE_MINUTE_IN_MILLIS
 // the entire state is serialized in a session
 let lastEventTime = 0
 
-// Strip transient identity fields before they hit storage. `lookupLoading` tracks whether a
-// lookup saga is currently in flight — only meaningful within a single session, so persisting
-// it would just create churn and risk restoring a phantom in-flight flag after a crash mid-fetch.
-export const stripIdentityTransients = createTransform<
-  ReducersRootState['identity'],
-  Omit<ReducersRootState['identity'], 'lookupLoading'>
->(
-  (inboundState) => {
-    const { lookupLoading: _drop, ...persistable } = inboundState
-    return persistable
-  },
-  (outboundState) => outboundState as ReducersRootState['identity'],
-  { whitelist: ['identity'] }
-)
-
 const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
@@ -55,7 +34,6 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],
-  transforms: [stripIdentityTransients],
   stateReconciler: autoMergeLevel2,
   migrate: async (...args) => {
     const migrate = createMigrate(migrations)

--- a/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
+++ b/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
@@ -6,14 +6,19 @@ import AppAnalytics from 'src/analytics/AppAnalytics'
 import { SendEvents } from 'src/analytics/Events'
 import { SendOrigin } from 'src/analytics/types'
 import { getAppConfig } from 'src/appConfig'
-import { fetchAddressVerification, fetchAddressesAndValidate } from 'src/identity/actions'
+import {
+  fetchAddressVerification,
+  fetchAddressesAndValidate,
+  recipientLookupResolved,
+} from 'src/identity/actions'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { RecipientType } from 'src/recipients/recipient'
 import SendSelectRecipient from 'src/send/SendSelectRecipient'
 import { getDynamicConfigParams } from 'src/statsig'
 import { StatsigDynamicConfigs } from 'src/statsig/types'
-import { createMockStore, getMockStackScreenProps } from 'test/utils'
+import { setupStore } from 'src/redux/store'
+import { createMockStore, getMockStackScreenProps, getMockStoreData } from 'test/utils'
 import {
   mockAccount,
   mockAccount2,
@@ -33,6 +38,10 @@ jest.mock('src/recipients/resolve-id')
 
 jest.mock('react-native-device-info', () => ({ getFontScaleSync: () => 1 }))
 jest.mock('src/statsig')
+jest.mock('src/redux/sagas', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  rootSaga: jest.fn(function* () {}),
+}))
 
 const mockScreenProps = ({
   defaultTokenIdOverride,
@@ -198,11 +207,12 @@ describe('SendSelectRecipient', () => {
     expect(getByTestId('SelectRecipient/NoResults')).toBeTruthy()
   })
   describe('selection spinner', () => {
-    it('shows the spinner on the tapped phone-recipient row while the lookup is in flight', async () => {
-      const store = createMockStore({
-        ...storeWithPhoneVerified,
-        identity: { recipientLookupLoading: true },
-      })
+    it('shows the spinner while the lookup is in flight and hides it once the saga resolves (error path)', async () => {
+      // Reducer-backed store: tapping a recipient dispatches `fetchAddressesAndValidate`
+      // which flips `recipientLookupLoading` to true; dispatching `recipientLookupResolved`
+      // (the saga's `finally` branch) flips it back to false. We assert the row spinner
+      // tracks the actual state transition, including the no-mapping (error) end state.
+      const { store } = setupStore(getMockStoreData(storeWithPhoneVerified))
 
       const { getByTestId, queryByTestId } = render(
         <Provider store={store}>
@@ -218,27 +228,9 @@ describe('SendSelectRecipient', () => {
       })
 
       expect(queryByTestId('RecipientItem/ActivityIndicator')).toBeTruthy()
-    })
-
-    it('hides the spinner once the lookup loading flag clears, even if no mapping arrived (error path)', async () => {
-      // No mapping in `e164NumberToAddress`, recipientLookupLoading false — mirroring the
-      // post-error state once the saga's `finally` block has dispatched `recipientLookupResolved`.
-      const store = createMockStore({
-        ...storeWithPhoneVerified,
-        identity: { recipientLookupLoading: false },
-      })
-
-      const { getByTestId, queryByTestId } = render(
-        <Provider store={store}>
-          <SendSelectRecipient {...mockScreenProps({})} />
-        </Provider>
-      )
 
       await act(() => {
-        fireEvent.changeText(getByTestId('SendSelectRecipientSearchInput'), 'George Bogart')
-      })
-      await act(() => {
-        fireEvent.press(getByTestId('RecipientItem'))
+        store.dispatch(recipientLookupResolved())
       })
 
       expect(queryByTestId('RecipientItem/ActivityIndicator')).toBeFalsy()

--- a/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
+++ b/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
@@ -201,9 +201,7 @@ describe('SendSelectRecipient', () => {
     it('shows the spinner on the tapped phone-recipient row while the lookup is in flight', async () => {
       const store = createMockStore({
         ...storeWithPhoneVerified,
-        identity: {
-          lookupLoading: { phoneNumber: { [mockE164Number2Invite]: true }, address: {} },
-        },
+        identity: { recipientLookupLoading: true },
       })
 
       const { getByTestId, queryByTestId } = render(
@@ -223,11 +221,11 @@ describe('SendSelectRecipient', () => {
     })
 
     it('hides the spinner once the lookup loading flag clears, even if no mapping arrived (error path)', async () => {
-      // No mapping in `e164NumberToAddress`, no entry in `phoneNumberLookupLoading` — mirroring
-      // the post-error state once the saga's `finally` block has cleared the flag.
+      // No mapping in `e164NumberToAddress`, recipientLookupLoading false — mirroring the
+      // post-error state once the saga's `finally` block has dispatched `recipientLookupResolved`.
       const store = createMockStore({
         ...storeWithPhoneVerified,
-        identity: { lookupLoading: { phoneNumber: {}, address: {} } },
+        identity: { recipientLookupLoading: false },
       })
 
       const { getByTestId, queryByTestId } = render(

--- a/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
+++ b/packages/wallet-stack/src/send/SendSelectRecipient.test.tsx
@@ -197,6 +197,56 @@ describe('SendSelectRecipient', () => {
     })
     expect(getByTestId('SelectRecipient/NoResults')).toBeTruthy()
   })
+  describe('selection spinner', () => {
+    it('shows the spinner on the tapped phone-recipient row while the lookup is in flight', async () => {
+      const store = createMockStore({
+        ...storeWithPhoneVerified,
+        identity: {
+          lookupLoading: { phoneNumber: { [mockE164Number2Invite]: true }, address: {} },
+        },
+      })
+
+      const { getByTestId, queryByTestId } = render(
+        <Provider store={store}>
+          <SendSelectRecipient {...mockScreenProps({})} />
+        </Provider>
+      )
+
+      await act(() => {
+        fireEvent.changeText(getByTestId('SendSelectRecipientSearchInput'), 'George Bogart')
+      })
+      await act(() => {
+        fireEvent.press(getByTestId('RecipientItem'))
+      })
+
+      expect(queryByTestId('RecipientItem/ActivityIndicator')).toBeTruthy()
+    })
+
+    it('hides the spinner once the lookup loading flag clears, even if no mapping arrived (error path)', async () => {
+      // No mapping in `e164NumberToAddress`, no entry in `phoneNumberLookupLoading` — mirroring
+      // the post-error state once the saga's `finally` block has cleared the flag.
+      const store = createMockStore({
+        ...storeWithPhoneVerified,
+        identity: { lookupLoading: { phoneNumber: {}, address: {} } },
+      })
+
+      const { getByTestId, queryByTestId } = render(
+        <Provider store={store}>
+          <SendSelectRecipient {...mockScreenProps({})} />
+        </Provider>
+      )
+
+      await act(() => {
+        fireEvent.changeText(getByTestId('SendSelectRecipientSearchInput'), 'George Bogart')
+      })
+      await act(() => {
+        fireEvent.press(getByTestId('RecipientItem'))
+      })
+
+      expect(queryByTestId('RecipientItem/ActivityIndicator')).toBeFalsy()
+    })
+  })
+
   it('navigates to send amount when a verified phone recipient is tapped in search results', async () => {
     const store = createMockStore({
       ...storeWithPhoneVerified,

--- a/packages/wallet-stack/src/send/SendSelectRecipient.tsx
+++ b/packages/wallet-stack/src/send/SendSelectRecipient.tsx
@@ -184,8 +184,13 @@ function SendSelectRecipient({ route }: Props) {
   const { contactRecipients, recentRecipients } = useSendRecipients()
   const { mergedRecipients, searchQuery, setSearchQuery } = useMergedSearchRecipients(onSearch)
 
-  const { recipientVerificationStatus, recipient, setSelectedRecipient, unsetSelectedRecipient } =
-    useFetchRecipientVerificationStatus()
+  const {
+    recipientVerificationStatus,
+    recipient,
+    setSelectedRecipient,
+    unsetSelectedRecipient,
+    isSelectedRecipientLoading,
+  } = useFetchRecipientVerificationStatus()
 
   useEffect(() => {
     // Auto-navigate once verification resolves. The picker stays mounted so the
@@ -280,9 +285,7 @@ function SendSelectRecipient({ route }: Props) {
             recipients={mergedRecipients}
             onSelectRecipient={setSelectedRecipient}
             selectedRecipient={recipient}
-            isSelectedRecipientLoading={
-              !!recipient && recipientVerificationStatus === RecipientVerificationStatus.UNKNOWN
-            }
+            isSelectedRecipientLoading={isSelectedRecipientLoading}
           />
         </>
       )
@@ -327,9 +330,7 @@ function SendSelectRecipient({ route }: Props) {
             recipients={contactRecipients}
             onSelectRecipient={setSelectedRecipient}
             selectedRecipient={recipient}
-            isSelectedRecipientLoading={
-              !!recipient && recipientVerificationStatus === RecipientVerificationStatus.UNKNOWN
-            }
+            isSelectedRecipientLoading={isSelectedRecipientLoading}
           />
         ) : (
           <>
@@ -344,9 +345,7 @@ function SendSelectRecipient({ route }: Props) {
                 title={t('sendSelectRecipient.recents')}
                 onSelectRecipient={onSelectRecentRecipient}
                 selectedRecipient={recipient}
-                isSelectedRecipientLoading={
-                  !!recipient && recipientVerificationStatus === RecipientVerificationStatus.UNKNOWN
-                }
+                isSelectedRecipientLoading={isSelectedRecipientLoading}
                 style={styles.recentRecipientPicker}
               />
             ) : (

--- a/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.test.tsx
+++ b/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.test.tsx
@@ -1,12 +1,22 @@
 import { act, renderHook } from '@testing-library/react-native'
 import * as React from 'react'
 import { Provider } from 'react-redux'
-import { fetchAddressVerification, fetchAddressesAndValidate } from 'src/identity/actions'
+import {
+  fetchAddressVerification,
+  fetchAddressesAndValidate,
+  recipientLookupResolved,
+} from 'src/identity/actions'
 import { RecipientVerificationStatus } from 'src/identity/types'
 import { Recipient, RecipientType } from 'src/recipients/recipient'
+import { setupStore } from 'src/redux/store'
 import useFetchRecipientVerificationStatus from 'src/send/useFetchRecipientVerificationStatus'
-import { createMockStore } from 'test/utils'
+import { getMockStoreData } from 'test/utils'
 import { mockAccount, mockE164Number, mockName } from 'test/values'
+
+jest.mock('src/redux/sagas', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  rootSaga: jest.fn(function* () {}),
+}))
 
 const phoneRecipient: Recipient = {
   name: mockName,
@@ -20,19 +30,15 @@ const addressRecipient: Recipient = {
   recipientType: RecipientType.Address,
 }
 
-function setupHook(
-  storeOverrides: Parameters<typeof createMockStore>[0] = {},
-  beforeMount?: () => void
-) {
-  const store = createMockStore(storeOverrides)
-  store.dispatch = jest.fn(store.dispatch)
-  if (beforeMount) beforeMount()
+function setupHook(storeOverrides: Parameters<typeof getMockStoreData>[0] = {}) {
+  const { store } = setupStore(getMockStoreData(storeOverrides))
+  const dispatchSpy = jest.spyOn(store, 'dispatch')
   const { result, rerender } = renderHook(() => useFetchRecipientVerificationStatus(), {
     wrapper: ({ children }: { children: React.ReactNode }) => (
       <Provider store={store}>{children}</Provider>
     ),
   })
-  return { result, rerender, store }
+  return { result, rerender, store, dispatchSpy }
 }
 
 describe('useFetchRecipientVerificationStatus', () => {
@@ -49,34 +55,23 @@ describe('useFetchRecipientVerificationStatus', () => {
 
   describe('phone-number recipient', () => {
     it('dispatches fetchAddressesAndValidate when selected', () => {
-      const { result, store } = setupHook()
+      const { result, dispatchSpy } = setupHook()
       act(() => {
         result.current.setSelectedRecipient(phoneRecipient)
       })
-      expect(store.dispatch).toHaveBeenCalledWith(fetchAddressesAndValidate(mockE164Number))
+      expect(dispatchSpy).toHaveBeenCalledWith(fetchAddressesAndValidate(mockE164Number))
     })
 
-    it('reports loading while recipientLookupLoading is true', () => {
-      const { result } = setupHook({
-        identity: { recipientLookupLoading: true },
-      })
+    it('reports loading once the lookup is dispatched and stops once it resolves', () => {
+      const { result, store } = setupHook()
+
       act(() => {
         result.current.setSelectedRecipient(phoneRecipient)
       })
       expect(result.current.isSelectedRecipientLoading).toBe(true)
-    })
 
-    it('stops loading when recipientLookupLoading becomes false (saga finished, success or error)', () => {
-      // Mirrors the saga's `finally` branch: the loading flag clears regardless of whether the
-      // request succeeded, so the picker spinner should stop.
-      const { result } = setupHook({
-        identity: {
-          recipientLookupLoading: false,
-          e164NumberToAddress: {},
-        },
-      })
       act(() => {
-        result.current.setSelectedRecipient(phoneRecipient)
+        store.dispatch(recipientLookupResolved())
       })
       expect(result.current.isSelectedRecipientLoading).toBe(false)
     })
@@ -84,13 +79,13 @@ describe('useFetchRecipientVerificationStatus', () => {
 
   describe('address recipient', () => {
     it('dispatches fetchAddressVerification when phone is verified', () => {
-      const { result, store } = setupHook({
+      const { result, dispatchSpy } = setupHook({
         app: { phoneNumberVerified: true },
       })
       act(() => {
         result.current.setSelectedRecipient(addressRecipient)
       })
-      expect(store.dispatch).toHaveBeenCalledWith(fetchAddressVerification(mockAccount))
+      expect(dispatchSpy).toHaveBeenCalledWith(fetchAddressVerification(mockAccount))
     })
 
     it('marks address recipient as unverified when phone is not verified', () => {
@@ -104,36 +99,28 @@ describe('useFetchRecipientVerificationStatus', () => {
       expect(result.current.isSelectedRecipientLoading).toBe(false)
     })
 
-    it('reports loading while recipientLookupLoading is true', () => {
-      const { result } = setupHook({
-        app: { phoneNumberVerified: true },
-        identity: { recipientLookupLoading: true },
-      })
+    it('reports loading once the lookup is dispatched and stops once it resolves', () => {
+      const { result, store } = setupHook({ app: { phoneNumberVerified: true } })
+
       act(() => {
         result.current.setSelectedRecipient(addressRecipient)
       })
       expect(result.current.isSelectedRecipientLoading).toBe(true)
-    })
 
-    it('stops loading once recipientLookupLoading is false (saga finished, success or error)', () => {
-      const { result } = setupHook({
-        app: { phoneNumberVerified: true },
-        identity: { recipientLookupLoading: false },
-      })
       act(() => {
-        result.current.setSelectedRecipient(addressRecipient)
+        store.dispatch(recipientLookupResolved())
       })
       expect(result.current.isSelectedRecipientLoading).toBe(false)
     })
   })
 
   it('clears recipient and verification status on unset', () => {
-    const { result } = setupHook({
-      identity: { recipientLookupLoading: true },
-    })
+    const { result } = setupHook()
     act(() => {
       result.current.setSelectedRecipient(phoneRecipient)
     })
+    expect(result.current.isSelectedRecipientLoading).toBe(true)
+
     act(() => {
       result.current.unsetSelectedRecipient()
     })

--- a/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.test.tsx
+++ b/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.test.tsx
@@ -56,9 +56,9 @@ describe('useFetchRecipientVerificationStatus', () => {
       expect(store.dispatch).toHaveBeenCalledWith(fetchAddressesAndValidate(mockE164Number))
     })
 
-    it('reports loading while phoneNumberLookupLoading[phone] is true', () => {
+    it('reports loading while recipientLookupLoading is true', () => {
       const { result } = setupHook({
-        identity: { lookupLoading: { phoneNumber: { [mockE164Number]: true }, address: {} } },
+        identity: { recipientLookupLoading: true },
       })
       act(() => {
         result.current.setSelectedRecipient(phoneRecipient)
@@ -66,26 +66,12 @@ describe('useFetchRecipientVerificationStatus', () => {
       expect(result.current.isSelectedRecipientLoading).toBe(true)
     })
 
-    it('stops loading when phoneNumberLookupLoading[phone] becomes false (success)', () => {
-      const { result } = setupHook({
-        identity: {
-          lookupLoading: { phoneNumber: { [mockE164Number]: false }, address: {} },
-          e164NumberToAddress: { [mockE164Number]: [mockAccount] },
-        },
-      })
-      act(() => {
-        result.current.setSelectedRecipient(phoneRecipient)
-      })
-      expect(result.current.isSelectedRecipientLoading).toBe(false)
-    })
-
-    it('stops loading once phoneNumberLookupLoading[phone] is false (saga finished, success or error)', () => {
+    it('stops loading when recipientLookupLoading becomes false (saga finished, success or error)', () => {
       // Mirrors the saga's `finally` branch: the loading flag clears regardless of whether the
-      // request succeeded, so the picker spinner should stop. We override the cached mapping to
-      // empty here to make sure loading state is not tied to whether mapping data arrived.
+      // request succeeded, so the picker spinner should stop.
       const { result } = setupHook({
         identity: {
-          lookupLoading: { phoneNumber: { [mockE164Number]: false }, address: {} },
+          recipientLookupLoading: false,
           e164NumberToAddress: {},
         },
       })
@@ -118,12 +104,10 @@ describe('useFetchRecipientVerificationStatus', () => {
       expect(result.current.isSelectedRecipientLoading).toBe(false)
     })
 
-    it('reports loading while addressLookupLoading[address] is true', () => {
+    it('reports loading while recipientLookupLoading is true', () => {
       const { result } = setupHook({
         app: { phoneNumberVerified: true },
-        identity: {
-          lookupLoading: { phoneNumber: {}, address: { [mockAccount.toLowerCase()]: true } },
-        },
+        identity: { recipientLookupLoading: true },
       })
       act(() => {
         result.current.setSelectedRecipient(addressRecipient)
@@ -131,12 +115,10 @@ describe('useFetchRecipientVerificationStatus', () => {
       expect(result.current.isSelectedRecipientLoading).toBe(true)
     })
 
-    it('stops loading once addressLookupLoading[address] is false (saga finished, success or error)', () => {
+    it('stops loading once recipientLookupLoading is false (saga finished, success or error)', () => {
       const { result } = setupHook({
         app: { phoneNumberVerified: true },
-        identity: {
-          lookupLoading: { phoneNumber: {}, address: { [mockAccount.toLowerCase()]: false } },
-        },
+        identity: { recipientLookupLoading: false },
       })
       act(() => {
         result.current.setSelectedRecipient(addressRecipient)
@@ -147,7 +129,7 @@ describe('useFetchRecipientVerificationStatus', () => {
 
   it('clears recipient and verification status on unset', () => {
     const { result } = setupHook({
-      identity: { lookupLoading: { phoneNumber: { [mockE164Number]: true }, address: {} } },
+      identity: { recipientLookupLoading: true },
     })
     act(() => {
       result.current.setSelectedRecipient(phoneRecipient)

--- a/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.test.tsx
+++ b/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.test.tsx
@@ -121,7 +121,9 @@ describe('useFetchRecipientVerificationStatus', () => {
     it('reports loading while addressLookupLoading[address] is true', () => {
       const { result } = setupHook({
         app: { phoneNumberVerified: true },
-        identity: { lookupLoading: { phoneNumber: {}, address: { [mockAccount.toLowerCase()]: true } } },
+        identity: {
+          lookupLoading: { phoneNumber: {}, address: { [mockAccount.toLowerCase()]: true } },
+        },
       })
       act(() => {
         result.current.setSelectedRecipient(addressRecipient)
@@ -132,7 +134,9 @@ describe('useFetchRecipientVerificationStatus', () => {
     it('stops loading once addressLookupLoading[address] is false (saga finished, success or error)', () => {
       const { result } = setupHook({
         app: { phoneNumberVerified: true },
-        identity: { lookupLoading: { phoneNumber: {}, address: { [mockAccount.toLowerCase()]: false } } },
+        identity: {
+          lookupLoading: { phoneNumber: {}, address: { [mockAccount.toLowerCase()]: false } },
+        },
       })
       act(() => {
         result.current.setSelectedRecipient(addressRecipient)

--- a/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.test.tsx
+++ b/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.test.tsx
@@ -1,0 +1,158 @@
+import { act, renderHook } from '@testing-library/react-native'
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { fetchAddressVerification, fetchAddressesAndValidate } from 'src/identity/actions'
+import { RecipientVerificationStatus } from 'src/identity/types'
+import { Recipient, RecipientType } from 'src/recipients/recipient'
+import useFetchRecipientVerificationStatus from 'src/send/useFetchRecipientVerificationStatus'
+import { createMockStore } from 'test/utils'
+import { mockAccount, mockE164Number, mockName } from 'test/values'
+
+const phoneRecipient: Recipient = {
+  name: mockName,
+  contactId: 'contactId',
+  e164PhoneNumber: mockE164Number,
+  recipientType: RecipientType.PhoneNumber,
+}
+
+const addressRecipient: Recipient = {
+  address: mockAccount,
+  recipientType: RecipientType.Address,
+}
+
+function setupHook(
+  storeOverrides: Parameters<typeof createMockStore>[0] = {},
+  beforeMount?: () => void
+) {
+  const store = createMockStore(storeOverrides)
+  store.dispatch = jest.fn(store.dispatch)
+  if (beforeMount) beforeMount()
+  const { result, rerender } = renderHook(() => useFetchRecipientVerificationStatus(), {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    ),
+  })
+  return { result, rerender, store }
+}
+
+describe('useFetchRecipientVerificationStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('starts with no recipient and not loading', () => {
+    const { result } = setupHook()
+    expect(result.current.recipient).toBeNull()
+    expect(result.current.recipientVerificationStatus).toBe(RecipientVerificationStatus.UNKNOWN)
+    expect(result.current.isSelectedRecipientLoading).toBe(false)
+  })
+
+  describe('phone-number recipient', () => {
+    it('dispatches fetchAddressesAndValidate when selected', () => {
+      const { result, store } = setupHook()
+      act(() => {
+        result.current.setSelectedRecipient(phoneRecipient)
+      })
+      expect(store.dispatch).toHaveBeenCalledWith(fetchAddressesAndValidate(mockE164Number))
+    })
+
+    it('reports loading while phoneNumberLookupLoading[phone] is true', () => {
+      const { result } = setupHook({
+        identity: { lookupLoading: { phoneNumber: { [mockE164Number]: true }, address: {} } },
+      })
+      act(() => {
+        result.current.setSelectedRecipient(phoneRecipient)
+      })
+      expect(result.current.isSelectedRecipientLoading).toBe(true)
+    })
+
+    it('stops loading when phoneNumberLookupLoading[phone] becomes false (success)', () => {
+      const { result } = setupHook({
+        identity: {
+          lookupLoading: { phoneNumber: { [mockE164Number]: false }, address: {} },
+          e164NumberToAddress: { [mockE164Number]: [mockAccount] },
+        },
+      })
+      act(() => {
+        result.current.setSelectedRecipient(phoneRecipient)
+      })
+      expect(result.current.isSelectedRecipientLoading).toBe(false)
+    })
+
+    it('stops loading once phoneNumberLookupLoading[phone] is false (saga finished, success or error)', () => {
+      // Mirrors the saga's `finally` branch: the loading flag clears regardless of whether the
+      // request succeeded, so the picker spinner should stop. We override the cached mapping to
+      // empty here to make sure loading state is not tied to whether mapping data arrived.
+      const { result } = setupHook({
+        identity: {
+          lookupLoading: { phoneNumber: { [mockE164Number]: false }, address: {} },
+          e164NumberToAddress: {},
+        },
+      })
+      act(() => {
+        result.current.setSelectedRecipient(phoneRecipient)
+      })
+      expect(result.current.isSelectedRecipientLoading).toBe(false)
+    })
+  })
+
+  describe('address recipient', () => {
+    it('dispatches fetchAddressVerification when phone is verified', () => {
+      const { result, store } = setupHook({
+        app: { phoneNumberVerified: true },
+      })
+      act(() => {
+        result.current.setSelectedRecipient(addressRecipient)
+      })
+      expect(store.dispatch).toHaveBeenCalledWith(fetchAddressVerification(mockAccount))
+    })
+
+    it('marks address recipient as unverified when phone is not verified', () => {
+      const { result } = setupHook({ app: { phoneNumberVerified: false } })
+      act(() => {
+        result.current.setSelectedRecipient(addressRecipient)
+      })
+      expect(result.current.recipientVerificationStatus).toBe(
+        RecipientVerificationStatus.UNVERIFIED
+      )
+      expect(result.current.isSelectedRecipientLoading).toBe(false)
+    })
+
+    it('reports loading while addressLookupLoading[address] is true', () => {
+      const { result } = setupHook({
+        app: { phoneNumberVerified: true },
+        identity: { lookupLoading: { phoneNumber: {}, address: { [mockAccount.toLowerCase()]: true } } },
+      })
+      act(() => {
+        result.current.setSelectedRecipient(addressRecipient)
+      })
+      expect(result.current.isSelectedRecipientLoading).toBe(true)
+    })
+
+    it('stops loading once addressLookupLoading[address] is false (saga finished, success or error)', () => {
+      const { result } = setupHook({
+        app: { phoneNumberVerified: true },
+        identity: { lookupLoading: { phoneNumber: {}, address: { [mockAccount.toLowerCase()]: false } } },
+      })
+      act(() => {
+        result.current.setSelectedRecipient(addressRecipient)
+      })
+      expect(result.current.isSelectedRecipientLoading).toBe(false)
+    })
+  })
+
+  it('clears recipient and verification status on unset', () => {
+    const { result } = setupHook({
+      identity: { lookupLoading: { phoneNumber: { [mockE164Number]: true }, address: {} } },
+    })
+    act(() => {
+      result.current.setSelectedRecipient(phoneRecipient)
+    })
+    act(() => {
+      result.current.unsetSelectedRecipient()
+    })
+    expect(result.current.recipient).toBeNull()
+    expect(result.current.recipientVerificationStatus).toBe(RecipientVerificationStatus.UNKNOWN)
+    expect(result.current.isSelectedRecipientLoading).toBe(false)
+  })
+})

--- a/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.ts
+++ b/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.ts
@@ -4,7 +4,7 @@ import { fetchAddressVerification, fetchAddressesAndValidate } from 'src/identit
 import {
   addressToVerifiedBySelector,
   e164NumberToAddressSelector,
-  lookupLoadingSelector,
+  recipientLookupLoadingSelector,
 } from 'src/identity/selectors'
 import { RecipientVerificationStatus } from 'src/identity/types'
 import { Recipient, RecipientType, getRecipientVerificationStatus } from 'src/recipients/recipient'
@@ -18,7 +18,7 @@ const useFetchRecipientVerificationStatus = () => {
 
   const e164NumberToAddress = useSelector(e164NumberToAddressSelector)
   const addressToVerifiedBy = useSelector(addressToVerifiedBySelector)
-  const lookupLoading = useSelector(lookupLoadingSelector)
+  const recipientLookupLoading = useSelector(recipientLookupLoadingSelector)
   const phoneNumberVerified = useSelector(phoneNumberVerifiedSelector)
   const dispatch = useDispatch()
 
@@ -56,17 +56,7 @@ const useFetchRecipientVerificationStatus = () => {
     }
   }, [e164NumberToAddress, addressToVerifiedBy, recipient, recipientVerificationStatus])
 
-  // True while the saga for the selected recipient is in flight. Both lookup sagas
-  // (`fetchAddressesAndValidate` for phone recipients, `fetchAddressVerification` for address
-  // recipients) set their respective flag on start and clear it in `finally`, so a failed lookup
-  // resolves the spinner identically to a successful one.
-  const isSelectedRecipientLoading = !recipient
-    ? false
-    : recipient.recipientType === RecipientType.PhoneNumber && recipient.e164PhoneNumber
-      ? !!lookupLoading.phoneNumber[recipient.e164PhoneNumber]
-      : recipient.address
-        ? !!lookupLoading.address[recipient.address.toLowerCase()]
-        : false
+  const isSelectedRecipientLoading = !!recipient && recipientLookupLoading
 
   return {
     recipient,

--- a/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.ts
+++ b/packages/wallet-stack/src/send/useFetchRecipientVerificationStatus.ts
@@ -1,7 +1,11 @@
 import { useEffect, useState } from 'react'
 import { phoneNumberVerifiedSelector } from 'src/app/selectors'
 import { fetchAddressVerification, fetchAddressesAndValidate } from 'src/identity/actions'
-import { addressToVerifiedBySelector, e164NumberToAddressSelector } from 'src/identity/selectors'
+import {
+  addressToVerifiedBySelector,
+  e164NumberToAddressSelector,
+  lookupLoadingSelector,
+} from 'src/identity/selectors'
 import { RecipientVerificationStatus } from 'src/identity/types'
 import { Recipient, RecipientType, getRecipientVerificationStatus } from 'src/recipients/recipient'
 import { useDispatch, useSelector } from 'src/redux/hooks'
@@ -14,6 +18,7 @@ const useFetchRecipientVerificationStatus = () => {
 
   const e164NumberToAddress = useSelector(e164NumberToAddressSelector)
   const addressToVerifiedBy = useSelector(addressToVerifiedBySelector)
+  const lookupLoading = useSelector(lookupLoadingSelector)
   const phoneNumberVerified = useSelector(phoneNumberVerifiedSelector)
   const dispatch = useDispatch()
 
@@ -51,11 +56,24 @@ const useFetchRecipientVerificationStatus = () => {
     }
   }, [e164NumberToAddress, addressToVerifiedBy, recipient, recipientVerificationStatus])
 
+  // True while the saga for the selected recipient is in flight. Both lookup sagas
+  // (`fetchAddressesAndValidate` for phone recipients, `fetchAddressVerification` for address
+  // recipients) set their respective flag on start and clear it in `finally`, so a failed lookup
+  // resolves the spinner identically to a successful one.
+  const isSelectedRecipientLoading = !recipient
+    ? false
+    : recipient.recipientType === RecipientType.PhoneNumber && recipient.e164PhoneNumber
+      ? !!lookupLoading.phoneNumber[recipient.e164PhoneNumber]
+      : recipient.address
+        ? !!lookupLoading.address[recipient.address.toLowerCase()]
+        : false
+
   return {
     recipient,
     setSelectedRecipient,
     unsetSelectedRecipient,
     recipientVerificationStatus,
+    isSelectedRecipientLoading,
   }
 }
 

--- a/packages/wallet-stack/test/RootStateSchema.json
+++ b/packages/wallet-stack/test/RootStateSchema.json
@@ -1955,6 +1955,28 @@
             ],
             "type": "object"
         },
+        "LookupLoadingType": {
+            "additionalProperties": false,
+            "properties": {
+                "address": {
+                    "additionalProperties": {
+                        "type": "boolean"
+                    },
+                    "type": "object"
+                },
+                "phoneNumber": {
+                    "additionalProperties": {
+                        "type": "boolean"
+                    },
+                    "type": "object"
+                }
+            },
+            "required": [
+                "address",
+                "phoneNumber"
+            ],
+            "type": "object"
+        },
         "NetworkId": {
             "enum": [
                 "arbitrum-one",
@@ -5532,6 +5554,9 @@
                         "string"
                     ]
                 },
+                "lookupLoading": {
+                    "$ref": "#/definitions/LookupLoadingType"
+                },
                 "shouldRefreshStoredPasswordHash": {
                     "type": "boolean"
                 }
@@ -5544,6 +5569,7 @@
                 "e164NumberToAddress",
                 "importContactsProgress",
                 "lastSavedContactsHash",
+                "lookupLoading",
                 "shouldRefreshStoredPasswordHash"
             ],
             "type": "object"

--- a/packages/wallet-stack/test/RootStateSchema.json
+++ b/packages/wallet-stack/test/RootStateSchema.json
@@ -1955,28 +1955,6 @@
             ],
             "type": "object"
         },
-        "LookupLoadingType": {
-            "additionalProperties": false,
-            "properties": {
-                "address": {
-                    "additionalProperties": {
-                        "type": "boolean"
-                    },
-                    "type": "object"
-                },
-                "phoneNumber": {
-                    "additionalProperties": {
-                        "type": "boolean"
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "address",
-                "phoneNumber"
-            ],
-            "type": "object"
-        },
         "NetworkId": {
             "enum": [
                 "arbitrum-one",
@@ -5554,8 +5532,8 @@
                         "string"
                     ]
                 },
-                "lookupLoading": {
-                    "$ref": "#/definitions/LookupLoadingType"
+                "recipientLookupLoading": {
+                    "type": "boolean"
                 },
                 "shouldRefreshStoredPasswordHash": {
                     "type": "boolean"
@@ -5569,7 +5547,7 @@
                 "e164NumberToAddress",
                 "importContactsProgress",
                 "lastSavedContactsHash",
-                "lookupLoading",
+                "recipientLookupLoading",
                 "shouldRefreshStoredPasswordHash"
             ],
             "type": "object"

--- a/packages/wallet-stack/test/schemas.ts
+++ b/packages/wallet-stack/test/schemas.ts
@@ -3802,7 +3802,7 @@ export const v258Schema = {
   },
   identity: {
     ...v257Schema.identity,
-    lookupLoading: { phoneNumber: {}, address: {} },
+    recipientLookupLoading: false,
   },
 }
 

--- a/packages/wallet-stack/test/schemas.ts
+++ b/packages/wallet-stack/test/schemas.ts
@@ -3794,6 +3794,18 @@ export const v257Schema = {
   identity: _.omit(v256Schema.identity, 'addressToVerificationStatus'),
 }
 
+export const v258Schema = {
+  ...v257Schema,
+  _persist: {
+    ...v257Schema._persist,
+    version: 258,
+  },
+  identity: {
+    ...v257Schema.identity,
+    lookupLoading: { phoneNumber: {}, address: {} },
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v257Schema as Partial<RootState>
+  return v258Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Adds a `recipientLookupLoading` boolean on the identity slice that the lookup sagas (`fetchAddressesAndValidateSaga`, `fetchAddressVerificationSaga`) flip to `true` on start (via the existing `FETCH_ADDRESSES_AND_VALIDATION_STATUS` / `FETCH_ADDRESS_VERIFICATION_STATUS` actions) and clear in `finally` by dispatching `recipientLookupResolved`. A single boolean is safe because both sagas use `takeLatest` — at most one lookup is in flight.

This gives the recipient picker a real "saga in flight" signal that resolves on both success and error. `useFetchRecipientVerificationStatus` now derives `isSelectedRecipientLoading` from this flag instead of the legacy `recipientVerificationStatus === UNKNOWN` heuristic, fixing the row spinner spinning indefinitely when a phone-number or address lookup fails.


| Before: infinte spinner | After: spinner hides on error |
|--------|--------|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-29 at 16 50 26" src="https://github.com/user-attachments/assets/1b2bf9a6-838b-40bd-a8a6-8e3ec895ba02" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-29 at 16 51 18" src="https://github.com/user-attachments/assets/188337c7-21f5-4be5-9fd9-a97419caa9fc" /> | 

### Test plan

- Updated unit tests

### Related issues

- Part of https://github.com/celo-org/celo-monorepo/issues/11734

### Backwards compatibility

Y

### Network scalability

NA