### PR TITLE
fix(walletconnect): split URI shape check from app config check

### DIFF
--- a/packages/wallet-stack/src/app/saga.ts
+++ b/packages/wallet-stack/src/app/saga.ts
@@ -260,9 +260,11 @@ function* watchDeepLinks() {
 
 export function* handleOpenUrl(action: OpenUrlAction) {
   const { url, openExternal, isSecureOrigin } = action
-  const walletConnectEnabled: boolean = yield* call(isWalletConnectEnabled, url)
   Logger.debug(TAG, 'Handling url', url)
-  if (isDeepLink(url) || (walletConnectEnabled && isWalletConnectDeepLink(url))) {
+  if (
+    isDeepLink(url) ||
+    (isWalletConnectDeepLink(url) && (yield* call(isWalletConnectEnabled)))
+  ) {
     // Handle celo links directly, this avoids showing the "Open with App" sheet on Android
     yield* call(handleDeepLink, openDeepLink(url, isSecureOrigin))
   } else if (/^https?:\/\//i.test(url) === true && !openExternal) {

--- a/packages/wallet-stack/src/app/saga.ts
+++ b/packages/wallet-stack/src/app/saga.ts
@@ -261,10 +261,7 @@ function* watchDeepLinks() {
 export function* handleOpenUrl(action: OpenUrlAction) {
   const { url, openExternal, isSecureOrigin } = action
   Logger.debug(TAG, 'Handling url', url)
-  if (
-    isDeepLink(url) ||
-    (isWalletConnectDeepLink(url) && (yield* call(isWalletConnectEnabled)))
-  ) {
+  if (isDeepLink(url) || (isWalletConnectDeepLink(url) && (yield* call(isWalletConnectEnabled)))) {
     // Handle celo links directly, this avoids showing the "Open with App" sheet on Android
     yield* call(handleDeepLink, openDeepLink(url, isSecureOrigin))
   } else if (/^https?:\/\//i.test(url) === true && !openExternal) {

--- a/packages/wallet-stack/src/dapps/saga.ts
+++ b/packages/wallet-stack/src/dapps/saga.ts
@@ -43,8 +43,10 @@ export function* handleOpenDapp(action: PayloadAction<DappSelectedAction>) {
   ).inAppWebviewEnabled
 
   if (dappsWebViewEnabled) {
-    const walletConnectEnabled: boolean = yield* call(isWalletConnectEnabled, dappUrl)
-    if (isDeepLink(dappUrl) || (walletConnectEnabled && isWalletConnectDeepLink(dappUrl))) {
+    if (
+      isDeepLink(dappUrl) ||
+      (isWalletConnectDeepLink(dappUrl) && (yield* call(isWalletConnectEnabled)))
+    ) {
       yield* call(handleDeepLink, openDeepLink(dappUrl, true))
     } else {
       navigate(Screens.WebViewScreen, { uri: dappUrl })

--- a/packages/wallet-stack/src/qrcode/utils.ts
+++ b/packages/wallet-stack/src/qrcode/utils.ts
@@ -88,11 +88,9 @@ export function* handleQRCodeDefault({
 }: HandleQRCodeDetectedAction) {
   AppAnalytics.track(QrScreenEvents.qr_scanned, qrCode)
 
-  const walletConnectEnabled: boolean = yield* call(isWalletConnectEnabled, qrCode.data)
-
   // TODO there's some duplication with deep links handing
   // would be nice to refactor this
-  if (qrCode.data.startsWith('wc:') && walletConnectEnabled) {
+  if (qrCode.data.startsWith('wc:') && (yield* call(isWalletConnectEnabled))) {
     yield* fork(handleLoadingWithTimeout, WalletConnectPairingOrigin.Scan)
     yield* call(initialiseWalletConnect, qrCode.data, WalletConnectPairingOrigin.Scan)
     return

--- a/packages/wallet-stack/src/walletConnect/saga.test.ts
+++ b/packages/wallet-stack/src/walletConnect/saga.test.ts
@@ -1098,9 +1098,9 @@ describe('isWalletConnectEnabled', () => {
       registryName: 'test',
       features: { walletConnect: { projectId: '123' } },
     })
-    jest.mocked(getFeatureGate).mockImplementation(
-      (gate) => gate === StatsigFeatureGates.DISABLE_WALLET_CONNECT_V2
-    )
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((gate) => gate === StatsigFeatureGates.DISABLE_WALLET_CONNECT_V2)
     expect(isWalletConnectEnabled()).toBe(false)
   })
 })

--- a/packages/wallet-stack/src/walletConnect/saga.test.ts
+++ b/packages/wallet-stack/src/walletConnect/saga.test.ts
@@ -36,6 +36,8 @@ import {
   handlePendingState,
   initialiseWalletConnect,
   initialiseWalletConnectV2,
+  isWalletConnectEnabled,
+  isWalletConnectV2Uri,
   normalizeTransactions,
   walletConnectSaga,
 } from 'src/walletConnect/saga'
@@ -1045,6 +1047,63 @@ describe('showActionRequest', () => {
 
 const v2ConnectionString =
   'wc:79a02f869d0f921e435a5e0643304548ebfa4a0430f9c66fe8b1a9254db7ef77@2?relay-protocol=irn&symKey=f661b0a9316a4ce0b6892bdce42bea0f45037f2c1bee9e118a3a4bc868a32a39'
+
+describe('isWalletConnectV2Uri', () => {
+  it('returns true for a v2 wc: URI', () => {
+    expect(isWalletConnectV2Uri(v2ConnectionString)).toBe(true)
+  })
+
+  it('returns false for any string that is not a wc: pairing URI', () => {
+    // parseUri is meant for wc: URIs only; passing anything else would force it
+    // down its base64 link-mode fallback, which can throw on RN's strict native
+    // base64 decoder. The startsWith('wc:') guard keeps non-WC strings out.
+    expect(isWalletConnectV2Uri('https://churrito.fi')).toBe(false)
+    expect(isWalletConnectV2Uri('testapp://wallet/wc?uri=wc:abc@2')).toBe(false)
+    expect(isWalletConnectV2Uri('')).toBe(false)
+  })
+
+  it('returns false for a v1 wc: URI', () => {
+    expect(isWalletConnectV2Uri('wc:abc@1?bridge=https%3A%2F%2Fbridge.walletconnect.org')).toBe(
+      false
+    )
+  })
+})
+
+describe('isWalletConnectEnabled', () => {
+  it('returns true when project id is set and v2 is not disabled', () => {
+    jest.mocked(getAppConfig).mockReturnValue({
+      displayName: 'Test App',
+      deepLinkUrlScheme: 'testapp',
+      registryName: 'test',
+      features: { walletConnect: { projectId: '123' } },
+    })
+    jest.mocked(getFeatureGate).mockReturnValue(false)
+    expect(isWalletConnectEnabled()).toBe(true)
+  })
+
+  it('returns false when project id is missing', () => {
+    jest.mocked(getAppConfig).mockReturnValue({
+      displayName: 'Test App',
+      deepLinkUrlScheme: 'testapp',
+      registryName: 'test',
+    })
+    jest.mocked(getFeatureGate).mockReturnValue(false)
+    expect(isWalletConnectEnabled()).toBe(false)
+  })
+
+  it('returns false when v2 is feature-gated off', () => {
+    jest.mocked(getAppConfig).mockReturnValue({
+      displayName: 'Test App',
+      deepLinkUrlScheme: 'testapp',
+      registryName: 'test',
+      features: { walletConnect: { projectId: '123' } },
+    })
+    jest.mocked(getFeatureGate).mockImplementation(
+      (gate) => gate === StatsigFeatureGates.DISABLE_WALLET_CONNECT_V2
+    )
+    expect(isWalletConnectEnabled()).toBe(false)
+  })
+})
 
 describe('initialiseWalletConnect', () => {
   const origin = WalletConnectPairingOrigin.Deeplink

--- a/packages/wallet-stack/src/walletConnect/saga.ts
+++ b/packages/wallet-stack/src/walletConnect/saga.ts
@@ -1123,31 +1123,29 @@ export function* initialiseWalletConnectV2(uri: string, origin: WalletConnectPai
   yield* put(initialisePairing(uri, origin))
 }
 
-export function isWalletConnectEnabled(uri: string) {
-  const { version } = parseUri(uri)
+export function isWalletConnectV2Uri(uri: string): boolean {
+  if (!uri.startsWith('wc:')) {
+    return false
+  }
+  return parseUri(uri).version === 2
+}
+
+export function isWalletConnectEnabled(): boolean {
   const walletConnectV2Disabled = getFeatureGate(StatsigFeatureGates.DISABLE_WALLET_CONNECT_V2)
   const walletConnectProjectId = getAppConfig().features?.walletConnect?.projectId
-
-  return !!walletConnectProjectId && !walletConnectV2Disabled && version === 2
+  return !!walletConnectProjectId && !walletConnectV2Disabled
 }
 
 export function* initialiseWalletConnect(uri: string, origin: WalletConnectPairingOrigin) {
-  const walletConnectEnabled = yield* call(isWalletConnectEnabled, uri)
-
-  const { version } = parseUri(uri)
-  if (!walletConnectEnabled) {
-    Logger.debug('initialiseWalletConnect', `v${version} is disabled, ignoring`)
+  if (!isWalletConnectV2Uri(uri)) {
+    Logger.debug('initialiseWalletConnect', 'URI is not a WalletConnect v2 link, ignoring')
     return
   }
-
-  switch (version) {
-    case 2:
-      yield* call(initialiseWalletConnectV2, uri, origin)
-      break
-    case 1:
-    default:
-      throw new Error(`Unsupported WalletConnect version '${version}'`)
+  if (!isWalletConnectEnabled()) {
+    Logger.debug('initialiseWalletConnect', 'WalletConnect is disabled, ignoring')
+    return
   }
+  yield* call(initialiseWalletConnectV2, uri, origin)
 }
 
 export function* showWalletConnectionSuccessMessage(dappName: string) {


### PR DESCRIPTION
### Description

Tapping certain dapps (e.g. ChurritoFi) crashed before opening, with `Input is not valid base64-encoded data.` from a saga. The root cause: `isWalletConnectEnabled(uri)` called `@walletconnect/utils`' `parseUri` on the dapp URL, which eagerly base64-decodes any input that doesn't contain `wc:` (to support link-mode URIs). With `react-native-quick-base64`'s strict native decoder, some plain `https://` URLs throw — `https://churrito.fi` is one of them.

### Fix

The previous `isWalletConnectEnabled(uri)` conflated two unrelated questions: *is this string a WC URI?* and *is WalletConnect configured in our app?* Splitting them removes the only reason we were ever passing dapp URLs through a WC URI parser.

- `isWalletConnectV2Uri(uri)` — `wc:` prefix check + `parseUri(...).version === 2`. Never invoked on non-`wc:` strings, so the base64 fallback can't fire.
- `isWalletConnectEnabled()` — pure config check (project id set, feature gate not disabled). No arguments.

Call sites become a plain conjunction of the two: a cheap prefix check on the URL, and a static config check. `initialiseWalletConnect` also drops a duplicate `parseUri` call and a dead `version === 1` switch case.

https://github.com/user-attachments/assets/2f407c0a-b84b-4a9c-8223-f4f6322f3be7

### Test plan

- Tested manually: ChurritoFi does open
- Updated unit test